### PR TITLE
update simulating spectra after desisim newexp refactor

### DIFF
--- a/simulating-desi-spectra.ipynb
+++ b/simulating-desi-spectra.ipynb
@@ -47,24 +47,17 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {},
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "WARNING:log.py:19:get_logger: desispec.log is deprecated, please use desiutil.log.\n",
-      "WARNING:log.py:19:get_logger: desispec.log is deprecated, please use desiutil.log.\n",
-      "WARNING:log.py:19:get_logger: desispec.log is deprecated, please use desiutil.log.\n"
-     ]
-    },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/Users/dummy/anaconda/lib/python3.6/site-packages/matplotlib/__init__.py:1405: UserWarning: \n",
-      "This call to matplotlib.use() has no effect because the backend has already\n",
-      "been chosen; matplotlib.use() must be called *before* pylab, matplotlib.pyplot,\n",
+      "/Users/sbailey/anaconda/envs/desi/lib/python3.5/site-packages/matplotlib/__init__.py:1401: UserWarning:  This call to matplotlib.use() has no effect\n",
+      "because the backend has already been chosen;\n",
+      "matplotlib.use() must be called *before* pylab, matplotlib.pyplot,\n",
       "or matplotlib.backends is imported for the first time.\n",
       "\n",
       "  warnings.warn(_use_error_msg)\n"
@@ -82,7 +75,9 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {},
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -125,19 +120,21 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {},
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "DESIMODEL environment set to /Users/dummy/desi/code/desimodel\n",
-      "DESI_ROOT environment set to /Users/dummy/desi\n",
-      "DESI_SPECTRO_SIM environment set to /Users/dummy/desi/spectro/sim\n",
-      "DESI_SPECTRO_DATA environment set to /Users/dummy/desi/spectro/data\n",
-      "DESI_SPECTRO_REDUX environment set to /Users/dummy/desi/spectro/redux\n",
-      "Required environment variable SPECPROD not set!\n",
-      "Required environment variable PIXPROD not set!\n"
+      "DESIMODEL environment set to /Users/sbailey/desi/git/desimodel/svn/trunk\n",
+      "DESI_ROOT environment set to /data/desi\n",
+      "DESI_SPECTRO_SIM environment set to /data/desi/spectro/sim\n",
+      "DESI_SPECTRO_DATA environment set to /data/desi/spectro/data\n",
+      "DESI_SPECTRO_REDUX environment set to /data/desi/spectro/redux\n",
+      "SPECPROD environment set to debug\n",
+      "PIXPROD environment set to debug\n"
      ]
     }
    ],
@@ -155,7 +152,9 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "metadata": {},
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -163,11 +162,11 @@
      "text": [
       "env: SPECPROD=example\n",
       "env: PIXPROD=example\n",
-      "env: DESI_SPECTRO_DATA=/Users/ioannis/research/projects/desi/spectro/sim/example/\n",
-      "Simulated raw data will be written to /Users/ioannis/research/projects/desi/spectro/sim/example/\n",
-      "Pipeline will read raw data from /Users/ioannis/research/projects/desi/spectro/sim/example/\n",
+      "env: DESI_SPECTRO_DATA=/data/desi/spectro/sim/example/\n",
+      "Simulated raw data will be written to /data/desi/spectro/sim/example/\n",
+      "Pipeline will read raw data from /data/desi/spectro/sim/example/\n",
       "    (without knowing that it was simulated)\n",
-      "Pipeline will write processed data to /Users/ioannis/research/projects/desi/spectro/redux/example\n"
+      "Pipeline will write processed data to /data/desi/spectro/redux/example\n"
      ]
     }
    ],
@@ -204,7 +203,7 @@
    "source": [
     "nspec = 100\n",
     "seed = 555\n",
-    "flavor = 'dark'\n",
+    "program = 'dark'\n",
     "night = '20170615'\n",
     "expid = 0"
    ]
@@ -231,35 +230,81 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "metadata": {},
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "INFO:io.py:625:read_basis_templates: Reading /Users/ioannis/research/projects/desi/spectro/templates/basis_templates/v2.3/elg_templates_v2.0.fits\n",
-      "INFO:io.py:625:read_basis_templates: Reading /Users/ioannis/research/projects/desi/spectro/templates/basis_templates/v2.3/elg_templates_v2.0.fits\n",
-      "INFO:io.py:625:read_basis_templates: Reading /Users/ioannis/research/projects/desi/spectro/templates/basis_templates/v2.3/lrg_templates_v1.3.fits\n",
-      "INFO:io.py:625:read_basis_templates: Reading /Users/ioannis/research/projects/desi/spectro/templates/basis_templates/v2.3/elg_templates_v2.0.fits\n",
-      "INFO:io.py:625:read_basis_templates: Reading /Users/ioannis/research/projects/desi/spectro/templates/basis_templates/v2.3/elg_templates_v2.0.fits\n",
-      "INFO:io.py:625:read_basis_templates: Reading /Users/ioannis/research/projects/desi/spectro/templates/basis_templates/v2.3/star_templates_v2.1.fits\n",
-      "INFO:io.py:625:read_basis_templates: Reading /Users/ioannis/research/projects/desi/spectro/templates/basis_templates/v2.3/lrg_templates_v1.3.fits\n",
-      "INFO:io.py:625:read_basis_templates: Reading /Users/ioannis/research/projects/desi/spectro/templates/basis_templates/v2.3/star_templates_v2.1.fits\n",
-      "INFO:io.py:625:read_basis_templates: Reading /Users/ioannis/research/projects/desi/spectro/templates/basis_templates/v2.3/star_templates_v2.1.fits\n",
-      "INFO:io.py:625:read_basis_templates: Reading /Users/ioannis/research/projects/desi/spectro/templates/basis_templates/v2.3/lrg_templates_v1.3.fits\n",
-      "INFO:io.py:625:read_basis_templates: Reading /Users/ioannis/research/projects/desi/spectro/templates/basis_templates/v2.3/lrg_templates_v1.3.fits\n",
-      "INFO:io.py:625:read_basis_templates: Reading /Users/ioannis/research/projects/desi/spectro/templates/basis_templates/v2.3/star_templates_v2.1.fits\n",
-      "INFO:io.py:625:read_basis_templates: Reading /Users/ioannis/research/projects/desi/spectro/templates/basis_templates/v2.3/star_templates_v2.1.fits\n",
-      "INFO:io.py:625:read_basis_templates: Reading /Users/ioannis/research/projects/desi/spectro/templates/basis_templates/v2.3/star_templates_v2.1.fits\n",
-      "INFO:obs.py:226:new_exposure: skyfile /Users/ioannis/repos/desihub/desimodel/data/spectra/spec-sky.dat\n",
-      "INFO:obs.py:297:new_exposure: Wrote /Users/ioannis/research/projects/desi/spectro/sim/example/20170615/fibermap-00000000.fits\n",
-      "INFO:obs.py:305:new_exposure: Wrote /Users/ioannis/research/projects/desi/spectro/sim/example/20170615/simspec-00000000.fits\n"
+      "DEBUG:obs.py:301:get_next_tileid: 8038 tiles in program DARK\n",
+      "DEBUG:obs.py:302:get_next_tileid: 1 observed tiles\n",
+      "DEBUG:obs.py:96:new_exposure: Generating 100 targets\n",
+      "DEBUG:targets.py:192:get_targets_parallel: Parallelizing get_targets using 2 cores\n",
+      "DEBUG:targets.py:251:get_targets: Using random seed 3083073946\n",
+      "DEBUG:targets.py:251:get_targets: Using random seed 86291744\n",
+      "INFO:io.py:787:read_basis_templates: Reading /data/desi/spectro/templates/basis_templates/v2.3/lrg_templates_v1.3.fits\n",
+      "DEBUG:templates.py:354:_blurmatrix: Populating blur matrix with 1 unique velocity dispersion values.\n",
+      "INFO:io.py:787:read_basis_templates: Reading /data/desi/spectro/templates/basis_templates/v2.3/lrg_templates_v1.3.fits\n",
+      "DEBUG:templates.py:354:_blurmatrix: Populating blur matrix with 1 unique velocity dispersion values.\n",
+      "INFO:io.py:787:read_basis_templates: Reading /data/desi/spectro/templates/basis_templates/v2.3/star_templates_v2.1.fits\n",
+      "INFO:io.py:787:read_basis_templates: Reading /data/desi/spectro/templates/basis_templates/v2.3/star_templates_v2.1.fits\n",
+      "INFO:io.py:787:read_basis_templates: Reading /data/desi/spectro/templates/basis_templates/v2.3/elg_templates_v2.0.fits\n",
+      "DEBUG:templates.py:354:_blurmatrix: Populating blur matrix with 3 unique velocity dispersion values.\n",
+      "INFO:io.py:787:read_basis_templates: Reading /data/desi/spectro/templates/basis_templates/v2.3/elg_templates_v2.0.fits\n",
+      "DEBUG:templates.py:354:_blurmatrix: Populating blur matrix with 4 unique velocity dispersion values.\n",
+      "INFO:io.py:787:read_basis_templates: Reading /data/desi/spectro/templates/basis_templates/v2.3/star_templates_v2.1.fits\n",
+      "INFO:io.py:787:read_basis_templates: Reading /data/desi/spectro/templates/basis_templates/v2.3/star_templates_v2.1.fits\n",
+      "DEBUG:simexp.py:370:simulate_spectra: loading specsim desi config\n",
+      "DEBUG:simexp.py:374:simulate_spectra: creating specsim desi simulator\n",
+      "DEBUG:specsim.py:39:get_simulator: Creating new  Simulator\n",
+      "WARNING:specsim.py:47:get_simulator: Treating BGS fiberloss = 0.5 * LRG fiberloss\n",
+      "INFO:simexp.py:395:simulate_spectra: MJD not in obsconditions, using DATE-OBS 2009-06-18T12:00:00.000\n",
+      "DEBUG:simexp.py:399:simulate_spectra: obsconditions MOONFRAC = 0.0\n",
+      "DEBUG:simexp.py:399:simulate_spectra: obsconditions EXPTIME = 1000\n",
+      "DEBUG:simexp.py:399:simulate_spectra: obsconditions SEEING = 1.1\n",
+      "DEBUG:simexp.py:399:simulate_spectra: obsconditions MOONALT = -60\n",
+      "DEBUG:simexp.py:399:simulate_spectra: obsconditions MOONSEP = 180\n",
+      "DEBUG:simexp.py:399:simulate_spectra: obsconditions AIRMASS = 1.0\n",
+      "DEBUG:simexp.py:517:get_source_types: elg 69 targets\n",
+      "DEBUG:simexp.py:517:get_source_types: lrg 13 targets\n",
+      "DEBUG:simexp.py:517:get_source_types: qso 8 targets\n",
+      "DEBUG:simexp.py:517:get_source_types: sky 8 targets\n",
+      "DEBUG:simexp.py:517:get_source_types: star 2 targets\n",
+      "DEBUG:simexp.py:435:simulate_spectra: running simulation\n",
+      "INFO:io.py:147:write_simspec: DATE-OBS 2017-06-15T22:00:00 UTC\n",
+      "INFO:io.py:223:write_simspec: Writing /data/desi/spectro/sim/example/20170615/simspec-00000000.fits\n",
+      "INFO:obs.py:205:new_exposure: Wrote /data/desi/spectro/sim/example/20170615/fibermap-00000000.fits\n"
      ]
     }
    ],
    "source": [
-    "fibermap, truth = new_exposure(flavor=flavor, nspec=nspec, seed=seed, night=night, \n",
-    "                               expid=expid, tileid=None, exptime=None)"
+    "sim, fibermap, meta, obsconditions = \\\n",
+    "    new_exposure(program=program, nspec=nspec, seed=seed, night=night, \n",
+    "                 expid=expid, tileid=None, exptime=None)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "dtype([('OBJTYPE', '<U10'), ('SUBTYPE', '<U10'), ('TEMPLATEID', '<i4'), ('SEED', '<i8'), ('REDSHIFT', '<f4'), ('MAG', '<f4'), ('DECAM_FLUX', '<f4', (6,)), ('WISE_FLUX', '<f4', (2,)), ('OIIFLUX', '<f4'), ('HBETAFLUX', '<f4'), ('EWOII', '<f4'), ('EWHBETA', '<f4'), ('D4000', '<f4'), ('VDISP', '<f4'), ('OIIDOUBLET', '<f4'), ('OIIIHBETA', '<f4'), ('OIIHBETA', '<f4'), ('NIIHBETA', '<f4'), ('SIIHBETA', '<f4'), ('ZMETAL', '<f4'), ('AGE', '<f4'), ('TEFF', '<f4'), ('LOGG', '<f4'), ('FEH', '<f4')])"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "meta.dtype"
    ]
   },
   {
@@ -273,19 +318,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
-   "metadata": {},
+   "execution_count": 10,
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "/Users/ioannis/research/projects/desi/spectro/sim/example/\r\n",
-      "/Users/ioannis/research/projects/desi/spectro/sim/example//20170615\r\n",
-      "/Users/ioannis/research/projects/desi/spectro/sim/example//20170615/fibermap-00000000.fits\r\n",
-      "/Users/ioannis/research/projects/desi/spectro/sim/example//20170615/simspec-00000000.fits\r\n",
-      "/Users/ioannis/research/projects/desi/spectro/sim/example//etc\r\n",
-      "/Users/ioannis/research/projects/desi/spectro/sim/example//etc/obslog.sqlite\r\n"
+      "/data/desi/spectro/sim/example/\r\n",
+      "/data/desi/spectro/sim/example//20170615\r\n",
+      "/data/desi/spectro/sim/example//20170615/fibermap-00000000.fits\r\n",
+      "/data/desi/spectro/sim/example//20170615/simspec-00000000.fits\r\n",
+      "/data/desi/spectro/sim/example//etc\r\n",
+      "/data/desi/spectro/sim/example//etc/obslog.sqlite\r\n"
      ]
     }
    ],
@@ -305,7 +352,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "metadata": {
     "collapsed": true
    },
@@ -317,18 +364,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
-   "metadata": {},
+   "execution_count": 12,
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Reading fibermap file /Users/ioannis/research/projects/desi/spectro/sim/example/20170615/fibermap-00000000.fits\n",
-      "Filename: /Users/ioannis/research/projects/desi/spectro/sim/example/20170615/fibermap-00000000.fits\n",
+      "Reading fibermap file /data/desi/spectro/sim/example/20170615/fibermap-00000000.fits\n",
+      "Filename: /data/desi/spectro/sim/example/20170615/fibermap-00000000.fits\n",
       "No.    Name         Type      Cards   Dimensions   Format\n",
-      "  0  PRIMARY     PrimaryHDU       6   ()      \n",
-      "  1  FIBERMAP    BinTableHDU     98   100R x 26C   [10A, 20A, 8A, K, K, K, K, 5E, 50A, J, K, J, J, J, J, E, D, D, D, D, D, D, D, D, E, E]   \n"
+      "0    PRIMARY     PrimaryHDU       6   ()              \n",
+      "1    FIBERMAP    BinTableHDU    107   100R x 26C   [10A, 20A, 8A, K, K, K, K, 5E, 50A, J, J, J, J, J, J, E, D, D, D, D, D, D, D, D, E, E]   \n"
      ]
     }
    ],
@@ -342,19 +391,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
-   "metadata": {},
+   "execution_count": 13,
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [
     {
      "data": {
       "text/html": [
        "&lt;Table length=3&gt;\n",
-       "<table id=\"table4641429376\" class=\"table-striped table-bordered table-condensed\">\n",
+       "<table id=\"table4588034312\" class=\"table-striped table-bordered table-condensed\">\n",
        "<thead><tr><th>OBJTYPE</th><th>TARGETCAT</th><th>BRICKNAME</th><th>TARGETID</th><th>DESI_TARGET</th><th>BGS_TARGET</th><th>MWS_TARGET</th><th>MAG [5]</th><th>FILTER [5]</th><th>SPECTROID</th><th>POSITIONER</th><th>LOCATION</th><th>DEVICE_LOC</th><th>PETAL_LOC</th><th>FIBER</th><th>LAMBDAREF</th><th>RA_TARGET</th><th>DEC_TARGET</th><th>RA_OBS</th><th>DEC_OBS</th><th>X_TARGET</th><th>Y_TARGET</th><th>X_FVCOBS</th><th>Y_FVCOBS</th><th>Y_FVCERR</th><th>X_FVCERR</th></tr></thead>\n",
-       "<thead><tr><th>str10</th><th>str20</th><th>str8</th><th>int64</th><th>int64</th><th>int64</th><th>int64</th><th>float32</th><th>str10</th><th>int32</th><th>int64</th><th>int32</th><th>int32</th><th>int32</th><th>int32</th><th>float32</th><th>float64</th><th>float64</th><th>float64</th><th>float64</th><th>float64</th><th>float64</th><th>float64</th><th>float64</th><th>float32</th><th>float32</th></tr></thead>\n",
-       "<tr><td>ELG</td><td></td><td>3331p155</td><td>5920414735219039951</td><td>2</td><td>0</td><td>0</td><td>23.1645 .. 21.7528</td><td>DECAM_G .. WISE_W2</td><td>0</td><td>95</td><td>95</td><td>95</td><td>0</td><td>0</td><td>5400.0</td><td>333.237503875</td><td>15.5578749931</td><td>333.237503875</td><td>15.5578749931</td><td>-4.13464340313</td><td>-176.016389199</td><td>-4.13464340313</td><td>-176.016389199</td><td>0.0</td><td>0.0</td></tr>\n",
-       "<tr><td>ELG</td><td></td><td>3334p155</td><td>5523080440782501539</td><td>2</td><td>0</td><td>0</td><td>22.9234 .. 22.1754</td><td>DECAM_G .. WISE_W2</td><td>0</td><td>62</td><td>62</td><td>62</td><td>0</td><td>1</td><td>5400.0</td><td>333.413137964</td><td>15.4815165289</td><td>333.413137964</td><td>15.4815165289</td><td>-45.5863791815</td><td>-157.134697634</td><td>-45.5863791815</td><td>-157.134697634</td><td>0.0</td><td>0.0</td></tr>\n",
-       "<tr><td>ELG</td><td></td><td>3334p157</td><td>7067568092200589017</td><td>2</td><td>0</td><td>0</td><td>21.8622 .. 21.6234</td><td>DECAM_G .. WISE_W2</td><td>0</td><td>102</td><td>102</td><td>102</td><td>0</td><td>2</td><td>5400.0</td><td>333.423893658</td><td>15.631559969</td><td>333.423893658</td><td>15.631559969</td><td>-48.26471976</td><td>-194.58679079</td><td>-48.26471976</td><td>-194.58679079</td><td>0.0</td><td>0.0</td></tr>\n",
+       "<thead><tr><th>str10</th><th>str20</th><th>str8</th><th>int64</th><th>int64</th><th>int64</th><th>int64</th><th>float32</th><th>str10</th><th>int32</th><th>int32</th><th>int32</th><th>int32</th><th>int32</th><th>int32</th><th>float32</th><th>float64</th><th>float64</th><th>float64</th><th>float64</th><th>float64</th><th>float64</th><th>float64</th><th>float64</th><th>float32</th><th>float32</th></tr></thead>\n",
+       "<tr><td>ELG</td><td></td><td>3331p155</td><td>337945246123920940</td><td>2</td><td>0</td><td>0</td><td>22.6272 .. 21.2409</td><td>DECAM_G .. WISE_W2</td><td>0</td><td>95</td><td>95</td><td>95</td><td>0</td><td>0</td><td>5400.0</td><td>333.237503875</td><td>15.5578749931</td><td>333.237503875</td><td>15.5578749931</td><td>-4.13464340313</td><td>-176.016389199</td><td>-4.13464340313</td><td>-176.016389199</td><td>0.0</td><td>0.0</td></tr>\n",
+       "<tr><td>ELG</td><td></td><td>3334p155</td><td>4797333920350256633</td><td>2</td><td>0</td><td>0</td><td>23.4359 .. 22.1747</td><td>DECAM_G .. WISE_W2</td><td>0</td><td>62</td><td>62</td><td>62</td><td>0</td><td>1</td><td>5400.0</td><td>333.413137964</td><td>15.4815165289</td><td>333.413137964</td><td>15.4815165289</td><td>-45.5863791815</td><td>-157.134697634</td><td>-45.5863791815</td><td>-157.134697634</td><td>0.0</td><td>0.0</td></tr>\n",
+       "<tr><td>ELG</td><td></td><td>3334p157</td><td>3577250621508241413</td><td>2</td><td>0</td><td>0</td><td>22.8845 .. 20.2277</td><td>DECAM_G .. WISE_W2</td><td>0</td><td>102</td><td>102</td><td>102</td><td>0</td><td>2</td><td>5400.0</td><td>333.423893658</td><td>15.631559969</td><td>333.423893658</td><td>15.631559969</td><td>-48.26471976</td><td>-194.58679079</td><td>-48.26471976</td><td>-194.58679079</td><td>0.0</td><td>0.0</td></tr>\n",
        "</table>"
       ],
       "text/plain": [
@@ -367,7 +418,7 @@
        "    ELG            3334p157 ...  -194.58679079      0.0      0.0"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -378,30 +429,33 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
-   "metadata": {},
+   "execution_count": 14,
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Reading simspec file /Users/ioannis/research/projects/desi/spectro/sim/example/20170615/simspec-00000000.fits.\n",
-      "Filename: /Users/ioannis/research/projects/desi/spectro/sim/example/20170615/simspec-00000000.fits\n",
+      "Reading simspec file /data/desi/spectro/sim/example/20170615/simspec-00000000.fits.\n",
+      "Filename: /data/desi/spectro/sim/example/20170615/simspec-00000000.fits\n",
       "No.    Name         Type      Cards   Dimensions   Format\n",
-      "  0  PRIMARY     PrimaryHDU      15   ()      \n",
-      "  1  WAVE        ImageHDU         9   (31901,)   float64   \n",
-      "  2  FLUX        ImageHDU         9   (31901, 100)   float32   \n",
-      "  3  SKYFLUX     ImageHDU         8   (31901,)   float32   \n",
-      "  4  WAVE_B      ImageHDU         9   (12326,)   float64   \n",
-      "  5  PHOT_B      ImageHDU         8   (12326, 100)   float32   \n",
-      "  6  SKYPHOT_B   ImageHDU         7   (12326,)   float32   \n",
-      "  7  WAVE_R      ImageHDU         9   (11205,)   float64   \n",
-      "  8  PHOT_R      ImageHDU         8   (11205, 100)   float32   \n",
-      "  9  SKYPHOT_R   ImageHDU         7   (11205,)   float32   \n",
-      " 10  WAVE_Z      ImageHDU         9   (12765,)   float64   \n",
-      " 11  PHOT_Z      ImageHDU         8   (12765, 100)   float32   \n",
-      " 12  SKYPHOT_Z   ImageHDU         7   (12765,)   float32   \n",
-      " 13  METADATA    BinTableHDU     61   100R x 24C   [10A, 10A, J, K, E, E, 6E, 2E, E, E, E, E, E, E, E, E, E, E, E, E, E, E, E, E]   \n"
+      "0    WAVE        PrimaryHDU      52   (31901,)     float64   \n",
+      "1    FLUX        ImageHDU         9   (31901, 100)   float32   \n",
+      "2    SKYFLUX     ImageHDU         9   (31901, 100)   float32   \n",
+      "3    WAVE_B      ImageHDU         7   (11896,)     float64   \n",
+      "4    PHOT_B      ImageHDU         9   (11896, 100)   float32   \n",
+      "5    SKYPHOT_B   ImageHDU         9   (11896, 100)   float32   \n",
+      "6    WAVE_R      ImageHDU         7   (10575,)     float64   \n",
+      "7    PHOT_R      ImageHDU         9   (10575, 100)   float32   \n",
+      "8    SKYPHOT_R   ImageHDU         9   (10575, 100)   float32   \n",
+      "9    WAVE_Z      ImageHDU         7   (11990,)     float64   \n",
+      "10   PHOT_Z      ImageHDU         9   (11990, 100)   float32   \n",
+      "11   SKYPHOT_Z   ImageHDU         9   (11990, 100)   float32   \n",
+      "12   TRUTH       BinTableHDU     57   100R x 24C   [10A, 10A, J, K, E, E, 6E, 2E, E, E, E, E, E, E, E, E, E, E, E, E, E, E, E, E]   \n",
+      "13   FIBERMAP    BinTableHDU     62   100R x 26C   [10A, 20A, 8A, K, K, K, K, 5E, 200A, J, J, J, J, J, J, E, D, D, D, D, D, D, D, D, E, E]   \n",
+      "14   OBSCONDITIONS  BinTableHDU     21   1R x 6C      [D, K, K, D, K, D]   \n"
      ]
     }
    ],
@@ -409,25 +463,27 @@
     "print('Reading simspec file {}.'.format(simspecfile))\n",
     "hdu = fits.open(simspecfile)\n",
     "hdu.info()\n",
-    "meta = Table(hdu['METADATA'].data)\n",
+    "meta = Table(hdu['TRUTH'].data)\n",
     "hdu.close()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
-   "metadata": {},
+   "execution_count": 15,
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [
     {
      "data": {
       "text/html": [
        "&lt;Table length=3&gt;\n",
-       "<table id=\"table4641429712\" class=\"table-striped table-bordered table-condensed\">\n",
+       "<table id=\"table4588035768\" class=\"table-striped table-bordered table-condensed\">\n",
        "<thead><tr><th>OBJTYPE</th><th>SUBTYPE</th><th>TEMPLATEID</th><th>SEED</th><th>REDSHIFT</th><th>MAG</th><th>DECAM_FLUX [6]</th><th>WISE_FLUX [2]</th><th>OIIFLUX</th><th>HBETAFLUX</th><th>EWOII</th><th>EWHBETA</th><th>D4000</th><th>VDISP</th><th>OIIDOUBLET</th><th>OIIIHBETA</th><th>OIIHBETA</th><th>NIIHBETA</th><th>SIIHBETA</th><th>ZMETAL</th><th>AGE</th><th>TEFF</th><th>LOGG</th><th>FEH</th></tr></thead>\n",
        "<thead><tr><th>str10</th><th>str10</th><th>int32</th><th>int64</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th></tr></thead>\n",
-       "<tr><td>ELG</td><td></td><td>3512</td><td>3244113739</td><td>1.25838</td><td>22.937</td><td>0.441517 .. 1.32143</td><td>2.19795 .. 1.99019</td><td>8.25246e-17</td><td>-1.0</td><td>73.3845</td><td>-1.0</td><td>1.00652</td><td>68.2661</td><td>0.733237</td><td>-0.0850786</td><td>0.275525</td><td>-0.248196</td><td>-0.19466</td><td>-1.0</td><td>-1.0</td><td>-1.0</td><td>-1.0</td><td>-1.0</td></tr>\n",
-       "<tr><td>ELG</td><td></td><td>4951</td><td>3952505139</td><td>0.820804</td><td>22.6349</td><td>0.616534 .. 1.59198</td><td>2.13285 .. 1.34848</td><td>4.69683e-17</td><td>-1.0</td><td>25.1577</td><td>-1.0</td><td>1.03366</td><td>40.1724</td><td>0.757255</td><td>-0.00885063</td><td>0.630011</td><td>-0.265495</td><td>-0.230491</td><td>-1.0</td><td>-1.0</td><td>-1.0</td><td>-1.0</td><td>-1.0</td></tr>\n",
-       "<tr><td>ELG</td><td></td><td>6928</td><td>369720621</td><td>1.11619</td><td>21.8746</td><td>1.64478 .. 2.487</td><td>2.91573 .. 2.2421</td><td>1.45983e-16</td><td>-1.0</td><td>48.7059</td><td>-1.0</td><td>0.990213</td><td>40.1724</td><td>0.698619</td><td>-0.00354248</td><td>0.468131</td><td>-0.177077</td><td>-0.244851</td><td>-1.0</td><td>-1.0</td><td>-1.0</td><td>-1.0</td><td>-1.0</td></tr>\n",
+       "<tr><td>ELG</td><td></td><td>4762</td><td>3244113739</td><td>0.996923</td><td>22.4456</td><td>0.817811 .. 2.51087</td><td>4.28999 .. 3.18879</td><td>3.68697e-17</td><td>-1.0</td><td>16.4576</td><td>-1.0</td><td>1.08793</td><td>146.259</td><td>0.733237</td><td>-0.0850786</td><td>0.275525</td><td>-0.248196</td><td>-0.19466</td><td>-1.0</td><td>-1.0</td><td>-1.0</td><td>-1.0</td><td>-1.0</td></tr>\n",
+       "<tr><td>ELG</td><td></td><td>3539</td><td>3952505139</td><td>0.740241</td><td>22.8313</td><td>0.372274 .. 1.44679</td><td>1.9299 .. 1.34932</td><td>7.07454e-17</td><td>-1.0</td><td>48.5398</td><td>-1.0</td><td>1.09407</td><td>144.413</td><td>0.757255</td><td>-0.00885063</td><td>0.630011</td><td>-0.265495</td><td>-0.230491</td><td>-1.0</td><td>-1.0</td><td>-1.0</td><td>-1.0</td><td>-1.0</td></tr>\n",
+       "<tr><td>ELG</td><td></td><td>2071</td><td>369720621</td><td>1.31487</td><td>22.649</td><td>0.586126 .. 2.98687</td><td>8.5183 .. 8.10832</td><td>9.76978e-17</td><td>-1.0</td><td>47.2831</td><td>-1.0</td><td>1.1539</td><td>62.3055</td><td>0.698619</td><td>-0.00354248</td><td>0.468131</td><td>-0.177077</td><td>-0.244851</td><td>-1.0</td><td>-1.0</td><td>-1.0</td><td>-1.0</td><td>-1.0</td></tr>\n",
        "</table>"
       ],
       "text/plain": [
@@ -435,12 +491,12 @@
        "OBJTYPE SUBTYPE TEMPLATEID    SEED    ...   AGE     TEFF    LOGG    FEH  \n",
        " str10   str10    int32      int64    ... float32 float32 float32 float32\n",
        "------- ------- ---------- ---------- ... ------- ------- ------- -------\n",
-       "    ELG               3512 3244113739 ...    -1.0    -1.0    -1.0    -1.0\n",
-       "    ELG               4951 3952505139 ...    -1.0    -1.0    -1.0    -1.0\n",
-       "    ELG               6928  369720621 ...    -1.0    -1.0    -1.0    -1.0"
+       "    ELG               4762 3244113739 ...    -1.0    -1.0    -1.0    -1.0\n",
+       "    ELG               3539 3952505139 ...    -1.0    -1.0    -1.0    -1.0\n",
+       "    ELG               2071  369720621 ...    -1.0    -1.0    -1.0    -1.0"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -460,26 +516,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 16,
    "metadata": {
+    "collapsed": false,
     "scrolled": true
    },
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "(-0.2, 2.3472768068313599)"
+       "(-0.2, 4.3580519676208498)"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     },
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYIAAAEKCAYAAAAfGVI8AAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAH+BJREFUeJzt3Xt8FeW1//HPSggCDQiVIAhF8IhUlIoYRbH1YC2Wo4gU\nUUTr/UjlohRFLqKgP7y+ELQVrUVrhSMiVYq11ks9LWqtdyJHRaooogZBEMGAiiCs3x+zkyaY7AzZ\ne2aHzPf9eu1X9syemWdl3Lgy8zyzHnN3REQkufJyHYCIiOSWEoGISMIpEYiIJJwSgYhIwikRiIgk\nnBKBiEjCKRGIiCScEoGISMIpEYiIJFyjXAcQRuvWrb1Tp065DkNEZLeyePHiT929qLbtdotE0KlT\nJ1599dVchyEislsxsw/CbKdbQyIiCadEICKScEoEIiIJt1v0EUiybNu2jdLSUrZs2ZLrUER2C02a\nNKFDhw4UFBTUaX8lAql3SktLad68OZ06dcLMch2OSL3m7qxfv57S0lI6d+5cp2Po1pDUO1u2bGGv\nvfZSEhAJwczYa6+9MrqCViKQeklJQCS8TP+9KBGIiCSc+gik3rvlqXeyerwxfQ+odZv8/Hy6d+9e\nsXz66aczYcIE+vTpw80330xxcXGV7V9++WXGjRvHqlWraN68Oe3atePGG2+scoyo3bHkjqweb0SP\nEbVuU1hYyObNm6usu/rqq7nrrrsoKipi69atXHXVVQwdOrTi8xkzZjBr1iwKCgrIy8vjuOOO46ab\nbqpzR2dtXv7ziqwe74iT9qt1m+uuu47777+f/Px88vLy+O1vf8v48eMrvjvvv/8+xx9/PNdeey3j\nx4/nxRdfpG3btgCMHDmSDh06MHHixKzGnY4SgUg1mjZtypIlS0Jt+8knn3Daaadx//3307t3bwCe\ne+453nvvvVgTQX0yZswYxo4dy/LlyznssMMYPHgwBQUF3Hnnnfz1r3/lxRdfpGXLlmzdupUZM2bw\n1VdfRZYI4vbCCy/w6KOPUlJSwh577MGnn37K1q1bKz4vLS2lX79+TJ8+nQEDBrBhwwbGjh3Lfffd\nR0lJCf/4xz9YvHhxrDErEYhkaObMmZxzzjkVSQDghz/8YQ4jqj+6dOlCs2bN2LBhA23atOG6667j\n2WefpWXLlgA0btyYCRMm5DjK7Fq9ejWtW7dmjz32AKB169ZVPjv77LO57rrrGDBgAADDhg1j9uzZ\nLFq0iCuuuIKZM2fGnhTVRyBSja+++ooePXpUvObPn1/jtkuXLqVnz54xRrf7KCkpoUuXLrRp04ay\nsjI2b95c5yGOu4vjjz+ejz76iAMOOIARI0bwzDPPVHx2zjnnMGrUKAYPHlyxLi8vj9/85jeccsop\ndO3alWOOOSb2mJUIRKpRfmuo/DVkyJDQ+/bq1YsDDzyQ0aNHRxhh/XbLLbdw0EEH0atXLyZNmlTt\nNk8++SQ9evSgU6dOPP/88zFHGJ3CwkIWL17MrFmzKCoqYsiQIdx7770A/OQnP+G+++7jyy+/rLJP\njx49OPjggxkxovZ+mSgoEYhk6KCDDqKkpKRi+aWXXmLq1Kl8/vnnOYwqt8aMGcPSpUtZsGABF1xw\nAVu2bKFFixYUFhby/vvvA/DTn/6UJUuWcPDBB1e5h94Q5Ofn06dPH6655hpmzpzJggULABg3bhyH\nH344p556Kt98802VffLy8sjLy83/kiNr1czuMbO1ZvZmpXXTzOxfZva6mS00s5ZRtS8Sl5EjR3Lv\nvfdW+at257/4kmrAgAEUFxcze/ZsACZOnMjw4cPZuHEjEDwV29BKibz99tssX768YnnJkiXsu+++\nFcu33norLVq04IILLsDdcxHit0TZWXwvMBOYU2ndU8BEd//GzG4CJgLjI4xBGoAwwz2zrbyPoFy/\nfv248cYbATjxxBMrOvOOOuooHnzwQebPn8/48eNZtWoVbdq0oXXr1kyePDnWmMMM98y2L7/8kg4d\nOlQsX3rppd/aZvLkyZxxxhlceOGFDB8+nC+++IJevXqxxx57UFhYyNFHH82hhx4aWYxhhntm0+bN\nm7n44ovZuHEjjRo1Yv/992fWrFkV/QJmxuzZs+nfvz/jxo1j2rRpscZXHYsyI5lZJ+BRdz+4ms9+\nBgx29zNrO05xcbFrYprkWLZsGQceeGCuwxDZrVT378bMFrt7cQ27VMhlH8H5wOM5bF9ERMhRIjCz\nScA3wNw02wwzs1fN7NV169bFF5yISMLEngjM7FygP3Cmp7kv5e6z3L3Y3YuLimqde1lEROoo1ieL\nzawfMA74T3fXsAoRkXogyuGj84AXgK5mVmpmFxCMImoOPGVmS8zszqjaFxGRcCK7InD3odWs/l1U\n7YmISN2o6JzUf4tuyO7xjq29vO/OZagffvhh2rRpw4UXXsjrr7+Ou9OyZUvmzp3LySefDMCaNWvI\nz8+nvE/r5ZdfpmnTpnTv3p1t27bRqFEjzj77bMaMGRPJE6TrbpuZ1eMVXTwq1HalpaWMHDmSt956\ni+3bt3PCCScwffp0tm/f/q3z9cQTT1BYWFhlnx07dtC/f3+mTZtG48aNs/o7ADz/YI1jUuqk96m1\njnj/VhnqVq1asWHDBjZv3sy6desq6i3dcccd9O7dm08//ZR27dpx2223cdFFF1Ucp1OnTjRv3hwz\no1WrVsyZM6fKw2nZokQgUo3qylDfcMMN7L333rzxxhtA8ARp27ZtK7a7+uqrKSwsZOzYsdUeZ+3a\ntZxxxhmUlZVxzTXXxPSbRMvdGTRoEMOHD+dPf/oT27dvZ9iwYYwbN462bdt+63wVFBTUuM+kSZPq\nxcNVmaqpDPU+++zD008/zc0338yjjz5aZZ8HH3yQI488knnz5lVJBACLFi2idevWTJkyhWuvvZa7\n7ror6zGr1pBISKtXr6Z9+/YVy127dq0oNRxGmzZtmDVrFjNnzqw3pQUy9fe//50mTZpw3nnnAcGV\n1C233MKcOXNYvnx5teerpn3uueeeBlGao7oy1Pvss0/afebNm8f06dNZtWoVpaWl1W5z1FFHsWrV\nqqzHC0oEItWqXIb6Zz/7GQDnn38+N910E0cddRRXXnlllXoyYe23335s376dtWvXZjvknFi6dCmH\nHXZYlXUtWrSgU6dOXHLJJdWer5r26dixI++++25ssUclXRnq6nz00UesXr2aI444gtNOO63GkudP\nPPEEAwcOjCJkJQKR6lQuQ71w4UIgKBW8YsUKLr/8cj777DMOP/xwli1bluNI67cknq90ZairM3/+\nfE477TQgmBJ13rx5VT4/9thjad++PY8//niVKT+zSX0EIrugsLCQQYMGMWjQIPLy8njsscd2qS7S\nihUryM/Pp02bNhFGGZ9u3brx0EMPVVlXVlbGmjVr6Nq1K02bNv3W+TrkkEOq3efDDz9k//33jzP8\nyJSXoe7Tpw/du3dn9uzZnHvuudVuO2/ePNasWcPcuUGn9scff8zy5cvp0qULEPQRtGzZkjPPPJMp\nU6YwY8aMrMerKwKRkP75z3+yYcMGALZu3cpbb721SyM41q1bx0UXXcSoUaMws6jCjNVxxx3Hl19+\nyZw5QZHh7du3c9lllzFq1ChKSkqqPV817XPuuefSrFmznP0u2VJbGerK3nnnHTZv3syqVatYuXIl\nK1euZOLEid+6KmjUqBG33norc+bM4bPPPst6zLoikPovxHDPOLz33nsMHz4cd2fHjh2ceOKJnHLK\nKWn3Ke9rKB8+etZZZ1Vbqjkbwg73zCYzY+HChYwcOZKpU6eybt06hgwZwqRJk5gzZ06156t8nxEj\nRjB16lR27NjBCSecwPXXXx9JjGGGe2ZTTWWoqzNv3ryKPqhyp5xyCkOGDPlWGfN27doxdOhQbr/9\ndq666qqsxhxpGepsURnqZFEZ6t3X888/z9ChQ1m4cKHmcY5ZJmWodUUgIlnTu3dvPvjgg1yHIbtI\nfQQiIgmnRCD10u5wy1Kkvsj030utt4bMrAtwA9ANaFKp4XgnApXEaNKkCevXr2evvfZqMKNr4vJJ\nWbiJ4Pdu0aT2jWS34O6sX7+eJk3q/t80TB/B74EpwC3AscB56EpCItShQwdKS0vRzHS7ruyrbaG2\n+6xpQcSRSJyaNGlChw4d6rx/mETQ1N3/Zmbm7h8AV5vZYmBybTuK1EVBQUFFdUbZNbc89U6o7cb0\nPSDiSGR3EiYRfG1mecByMxsFrAIKow1LRETiEuYWz2igGXAJcBjwc+CcKIMSEZH4pL0iMLN8YIi7\njwU2E/QPiIhIA5L2isDdtwM/jCkWERHJgTB9BK+Z2SPAg8AX5Svd/Y+RRSUiIrEJkwiaAOuBH1da\n54ASgYhIAxAmEdzt7v+svMLMjo4oHhERiVmYUUO3hVwnIiK7oRqvCMzsKKA3UGRmlQuotwDyow5M\nRETike6KoDHBg2ONgOaVXmXA4NoObGb3mNlaM3uz0rrvmtlTZrY89bNVZuGLiEimarwicPdngGfM\n7N5UaYlddS8wE5hTad0E4G/ufqOZTUgtj6/DsUVEJEvC9BHcbWYtyxfMrJWZPVnbTu7+LLDz5Jon\nA7NT72cDA8MGKiIi0QiTCFq7+8byBXffALSpY3t7u/vq1Ps1wN51PI6IiGRJmESww8w6li+Y2b4E\nzxFkxIOZFGo8jpkNM7NXzexVlSMWEYlOmOcIJgHPmdkzgAE/AobVsb1PzKydu682s3bA2po2dPdZ\nwCwIJq+vY3siIlKLWq8I3P0JoCcwH3gAOMzda+0jqMEj/Lty6TnAn+p4HBERyZJaE4EFcwX2A3q6\n+6NAMzM7IsR+84AXgK5mVmpmFwA3An3NbDnwk9SyiIjkUJhbQ3cAOwhqDf0/YBOwADg83U7uPrSG\nj47blQBFRCRaYRJBL3fvaWavQTBqyMwaRxyXiIjEJMyooW2pCWocwMyKCK4QRESkAQiTCH4NLAT2\nNrPrgOeA6yONSkREYlPrrSF3n2tmi/n3vf2B7r4s2rBERCQuYfoIIJi8vvz2UNPowhERkbiFGT46\nmaAu0HeB1sDvzezKqAMTEZF4hLkiOBM4xN23AJjZjcAS4NooAxMRkXiE6Sz+mGDe4nJ7AKuiCUdE\nROIW5orgc2CpmT1F0EfQF3jZzH4N4O6XRBifiIhELEwiWJh6lXs6mlBERCQXwgwfnQ1gZgXAwcAq\nd6+xaqiIiOxeauwjMLM7zeyg1Ps9gf8jmHbyNTOrqY6QiIjsZtJ1Fv/I3Zem3p8HvOPu3YHDgHGR\nRyYiIrFIlwi2VnrfF3gYwN3XRBqRiIjEKl0i2Ghm/c3sUOBo4AkAM2uEni4WEWkw0nUW/4Kg4Fxb\n4JeVrgSOA/4SdWAiIhKPGhOBu79DMDPZzuufBOo6VaWIiNQzYZ4sFhGRBkyJQEQk4ZQIREQSrsY+\nAjO7NN2O7j4j++GIiEjc0o0aap762RU4HHgktXwS8HKUQYmISHzSjRq6BsDMngV6uvum1PLVaPio\niEiDEaaPYG+qPmW8NbVOREQagDBlqOcQzD9QXop6IMHUlXVmZmOA/yaY3+AN4LzyGdBERCRetV4R\nuPt1BEXnNqRe57n79XVt0MzaA5cAxe5+MJAPnF7X44mISGbCDh9tBpS5+6+AUjPrnGG7jYCmqbpF\nzQimwxQRkRyoNRGY2RRgPDAxtaoAuK+uDbr7KuBm4ENgNfC5u/+1rscTEZHMhOkj+BlwKFAC4O4f\nm1nz9LvUzMxaAScDnYGNwINm9nN3v2+n7YYBwwA6duxY1+aq9fKfV4Ta7oiT9stquyJ1dctT7+Q6\nBGnAwtwa2uruTtCxi5l9J8M2fwK87+7r3H0b8Eeg984bufssdy929+KioqIMmxQRkZqESQR/MLPf\nAi3N7ELgf4G7M2jzQ+BIM2tmZkZQ1npZBscTEZEMhJm8/mYz6wuUETxlPNndn6prg+7+kpk9RHCr\n6RvgNWBWXY8nIiKZqTURmNlN7j4eeKqadXXi7lOAKXXdX0REsifMraG+1az7r2wHIiIiuZGu+uhw\nYASwn5m9Xumj5sA/ow5MRETike7W0P3A48ANwIRK6ze5+2eRRiUiIrFJV330c+BzYCiAmbUBmgCF\nZlbo7h/GE6KIiEQpzJPFJ5nZcuB94BlgJcGVgoiINABhOouvBY4E3nH3zgTj/l+MNCoREYlNmESw\nzd3XA3lmlufui4DiiOMSEZGYhKk1tNHMCoFngblmthb4ItqwREQkLmGuCE4GvgLGAE8A7xHMWywi\nIg1AmBITlf/6z2hmMhERqX/SPVC2iVTF0Z0/AtzdW0QWlYiIxCbdcwR1nnNAROq3sPMbjOl7QMSR\nSH0QpuhctbPC6IEyEZGGIcyoob9Uet+EYGaxt4GDIolIRERiFaazuHvlZTPrSVCMTkREGoAww0er\ncPcSoFcEsYiISA6E6SO4tNJiHtAT+DiyiEREJFZh+ggqjx76hqDPYEE04YiISNzC9BFcE0cgIiKS\nG2FuDRUDk4B9K2/v7j+IMC4REYlJmFtDc4HLgTeAHdGGIyIicQuTCNa5+yORRyIiIjkRJhFMMbO7\ngb8BX5evdPc/RhaViIjEJkwiOA/4PlDAv28NOaBEICLSAIRJBIe7e9dsNmpmLYG7gYMJksr57v5C\nNtsQEZFwwjxZ/LyZdctyu78CnnD37wOHAMuyfHwREQkpzBXBkcASM3ufoI+gfD6COg0fNbM9gWOA\ncwkOtBXYWpdjiYhI5sIkgn5ZbrMzsA74vZkdAiwGRu80E5qIiMQk3QxlLdy9DNgUQZs9gYvd/SUz\n+xUwAbhqp/aHAcMAOnasdkoEkVhpMhdpqNL1Edyf+rkYeDX1c3Gl5boqBUrd/aXU8kMEiaEKd5/l\n7sXuXlxUVJRBcyIikk66qSr7p352zmaD7r7GzD4ys67u/jZwHPBWNtsQEZHw0t0a2hfY6O6fp5aP\nBQYCK4HbU528dXUxMNfMGgMrCJ5VEBGRHEh3a+gPwHcAzKwH8CDwIdADuCOTRt19Seq2zw/cfaC7\nb8jkeCIiUnfpRg01dffyCWh+Dtzj7tPNLA9YEn1oIiISh3RXBFbp/Y8Jag3h7qpAKiLSgKS7Ivi7\nmf0BWA20Av4OYGbt0ANgIiINRrpE8EtgCNAO+KG7b0utb0swUY2IiDQA6YaPOvBANetfizQiERGJ\nVZiicyIi0oApEYiIJFyNicDM/pb6eVN84YiISNzSdRa3M7PewAAze4Cqw0lx95JIIxMRkVikSwST\nCSqCdgBm7PSZEzxbICIiu7l0o4YeAh4ys6vcfWqMMYmISIxqnZjG3aea2QCCWcUAnnb3R6MNS6Rm\nDWlegLC/i0iUah01ZGY3AKMJSkW/BYw2s+ujDkxEROIRZqrKE4Ee5TWGzGw28BpwRZSBiYhIPMI+\nR9Cy0vs9owhERERyI8wVwQ3Aa2a2iGAI6TEEcwyLiEgDEKazeJ6ZPQ0cnlo13t3XRBqViIjEJswV\nAe6+Gngk4lhERCQHVGtIRCThlAhERBIubSIws3wz+1dcwYiISPzSJgJ33w68bWYdY4pHRERiFqaz\nuBWw1MxeBr4oX+nuAyKLSkREYhMmEVwVeRQiIpIzYZ4jeMbM9gW6uPv/mlkzID/Ths0sH3gVWOXu\n/TM9noiI1E2YonMXAg8Bv02tag88nIW2RwPLsnAcERHJQJjhoyOBo4EyAHdfDrTJpFEz60BQzO7u\nTI4jIiKZC5MIvnb3reULZtaIYIayTNwKjAN2ZHgcERHJUJjO4mfM7AqgqZn1BUYAf65rg2bWH1jr\n7ovNrE+a7YYBwwA6dszy6NWVz4XccL/stptQZy0IN8Hd/5wSblxCSdn8kC2HO162J4fRZDOyuwlz\nRTABWAe8AfwCeAy4MoM2jwYGmNlK4AHgx2Z2384bufssdy929+KioqIMmhMRkXTCjBrakZqM5iWC\nW0Jvu3udbw25+0RgIkDqimCsu/+8rscTEZHM1JoIzOxE4E7gPYL5CDqb2S/c/fGogxMRkeiF6SOY\nDhzr7u8CmNl/AH8BMk4E7v408HSmxxERkboL00ewqTwJpKwANkUUj4iIxKzGKwIzG5R6+6qZPQb8\ngaCP4FTglRhiExGRGKS7NXRSpfefAP+Zer8OaBpZRCIiEqsaE4G7nxdnICIikhthRg11Bi4GOlXe\nXmWoRUQahjCjhh4GfkfwNLFKQoiINDBhEsEWd/915JGIiEhOhEkEvzKzKcBfga/LV7p7SWRRiYhI\nbMIkgu7AWcCP+fetIU8ti4jIbi5MIjgV2K9yKWoREWk4wjxZ/CbQMupAREQkN8JcEbQE/mVmr1C1\nj0DDRxMsipr7YectCEvzAoiEEyYRTIk8ChERyZkw8xE8E0cgIiKSG2GeLN7Ev+cobgwUAF+4e4so\nAxMRkXiEuSJoXv7ezAw4GTgyyqBERCQ+YUYNVfDAw8BPI4pHRERiFubW0KBKi3lAMbAlsohERCRW\nYUYNVZ6X4BtgJcHtIRERaQDC9BFoXgIRkQYs3VSVk9Ps5+6e3ad/REQkJ9JdEXxRzbrvABcAewFK\nBCIiDUC6qSqnl783s+bAaOA84AFgek37iYjI7iVtH4GZfRe4FDgTmA30dPcNcQQmIiLxqPE5AjOb\nBrwCbAK6u/vV2UgCZvY9M1tkZm+Z2VIzG53pMUVEpO7SPVB2GbAPcCXwsZmVpV6bzKwsgza/AS5z\n924ETyiPNLNuGRxPREQykK6PYJeeOg7L3VcDq1PvN5nZMqA98FYU7YmISHqR/M8+LDPrBBwKvJTL\nOEREkizMk8WRMLNCYAHwS3f/1q0mMxsGDAPo2LFjVtv+4IM3Q213RFZblfqqpGx+qO16thgScST1\nT7Yn9xnT94CsHk+yIydXBGZWQJAE5rr7H6vbxt1nuXuxuxcXFRXFG6CISILEnghSpax/Byxz9xlx\nty8iIlXl4orgaOAs4MdmtiT1OiEHcYiICDnoI3D35wCLu10REaleTkcNiYhI7ikRiIgknBKBiEjC\nKRGIiCScEoGISMIpEYiIJJwSgYhIwikRiIgknBKBiEjCKRGIiCScEoGISMLlbD4CqZ/uWHJHqO1K\nytaHPuaP/vZ6qO3+cdwPQh8zjLDzDEjm9n9sXrgN+06JNpB6aN1tM0NtV3TxqIgjqZmuCEREEk6J\nQEQk4ZQIREQSTolARCThlAhERBJOiUBEJOGUCEREEk6JQEQk4ZQIREQSTolARCThlAhERBJOiUBE\nJOFykgjMrJ+ZvW1m75rZhFzEICIigdgTgZnlA7cD/wV0A4aaWbe44xARkUAurgiOAN519xXuvhV4\nADg5B3GIiAi5SQTtgY8qLZem1omISA6Yu8fboNlgoJ+7/3dq+Sygl7uP2mm7YcCw1GJX4O0YwmsN\nfBpDO/WdzkNA50HnoNzueh72dfei2jbKxQxlq4DvVVrukFpXhbvPAmbFFRSAmb3q7sVxtlkf6TwE\ndB50Dso19POQi1tDrwBdzKyzmTUGTgceyUEcIiJCDq4I3P0bMxsFPAnkA/e4+9K44xARkUBOJq93\n98eAx3LRdi1ivRVVj+k8BHQedA7KNejzEHtnsYiI1C8qMSEiknCJTAS1lbiwwK9Tn79uZj1zEWfU\nQpyHPmb2uZktSb0m5yLOKJnZPWa21szerOHzpHwXajsPSfgufM/MFpnZW2a21MxGV7NNw/w+uHui\nXgQd1O8B+wGNgf8Duu20zQnA44ABRwIv5TruHJ2HPsCjuY414vNwDNATeLOGzxv8dyHkeUjCd6Ed\n0DP1vjnwTlL+35DEK4IwJS5OBuZ44EWgpZm1izvQiKnUB+DuzwKfpdkkCd+FMOehwXP31e5eknq/\nCVjGt6seNMjvQxITQZgSF0kogxH2d+ydugR+3MwOiie0eiUJ34WwEvNdMLNOwKHASzt91CC/DzkZ\nPiq7jRKgo7tvNrMTgIeBLjmOSXIjMd8FMysEFgC/dPeyXMcThyReEYQpcRGqDMZurtbf0d3L3H1z\n6v1jQIGZtY4vxHohCd+FWiXlu2BmBQRJYK67/7GaTRrk9yGJiSBMiYtHgLNTIwSOBD5399VxBxqx\nWs+DmbU1M0u9P4Lg+7I+9khzKwnfhVol4buQ+v1+Byxz9xk1bNYgvw+JuzXkNZS4MLOLUp/fSfDU\n8wnAu8CXwHm5ijcqIc/DYGC4mX0DfAWc7qmhEw2Fmc0jGBHT2sxKgSlAASTnuwChzkOD/y4ARwNn\nAW+Y2ZLUuiuAjtCwvw96slhEJOGSeGtIREQqUSIQEUk4JQIRkYRTIhARSTglAhGRhFMikMQxs+2p\nCppvmtmfzazlLu5/tZmNrcvnZvZ8pffTUlUup5nZQDPrtitxiGSLEoEk0Vfu3sPdDyYotDYyrobd\nvXelxWHAD9z9cmAgoEQgOaFEIEn3ApWKhpnZ5Wb2Sqq42jWV1k8ys3fM7Dmga6X1l6Tq179uZg9U\nOm43M3vazFaY2SWVtt+c+vkIUAgsNrMpwABgWupK5T8i+21FqpG4J4tFyplZPnAcQVkBzOx4gkJq\nRxDUm3/EzI4BviAowdGD4N9MCbA4dZgJQGd3/3qnW0zfB44lqGv/tpn9xt23lX/o7gPMbLO790i1\n3Zmg3v9Dkf3CIjVQIpAkapoqIdCeoOb8U6n1x6der6WWCwkSQ3Ngobt/CRV/zZd7HZhrZg8TVOQs\n9xd3/xr42szWAnsTlCwWqXd0a0iS6KvUX+L7EvzlX95HYMANqf6DHu6+v7v/rpZjnQjcTjC71ytm\nVv7H1deVttmO/uiSekyJQBIr9Rf+JcBlqf+BPwmcn6pHj5m1N7M2wLPAQDNrambNgZNSn+cB33P3\nRcB4YE+Cq4i62ERw5SESO/2VIonm7q+Z2evAUHf/HzM7EHghVXF5M/Bzdy8xs/kE8zqvJSjhDUHV\n1vvMbE+Cq4lfu/vG1L676gHgrlTH8mB3fy+z30wkPFUfFRFJON0aEhFJOCUCEZGEUyIQEUk4JQIR\nkYRTIhARSTglAhGRhFMiEBFJOCUCEZGE+/+9FTq/Gxe6LwAAAABJRU5ErkJggg==\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAbYAAAElCAYAAACI+8edAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAAMTQAADE0B0s6tTgAAIABJREFUeJzt3Xl8VdX1///XIqAgpRUUnJGPiuCAJrIsrVMFtc5jW6mt\nWi1V0DoAStV+1Fasn1apcail4McBtfKT1gEnWkTFoc4biKKfn+IAImqBqigKAoH9/ePexJt4k5wk\n9+beXN7PxyOPnGGfc9a9jazuc/ZZ22KMiIiIlIoOhQ5AREQkl5TYRESkpCixiYhISVFiExGRkqLE\nJiIiJUWJTURESooSm4iIlBQlNhERKSlKbCIiUlKU2EREpKR0LHQA+TRmzJi4xRZbFDoMERFppcmT\nJ98bQvhBkrZ5TWzu3hm4C9gZWAksAc4IIbzl7r2A24HtgVXAmSGEpxo4zyDgRqALsAg4KYTwflPX\n32KLLRg9enROPouIiBTO5MmT303ati1uRd4I9Ash7A7cD9yU3v4H4PkQQl/gVGCyu3eqf7C7dwDu\nBEaGEHYEpgHXtkHcIiLSDuU1sYUQvgwhTAsh1Ewh8DzQJ718PDAh3e4l4APge1lOMxCoDiHMTK9P\nBI5M9wZFRETqaOvBI+cC97v7JkCnEMK/M/YtAHpnOaY3UNsFDSEsBz4DtsxjnCIi0k612eARd/81\nsANwAKlnZfm4xmig9qFaRUVFPi4jIiJFrE0Sm7ufDxwHHBhCWAGscPdqd988o9fWB1iY5fCFwLYZ\n5+oGfIvUrcs6QgiVQGXNemVlpWZRlSZ98cUXLF++HDMrdCgi67UYI926daNr166tOk/eE1u6F3UC\nqaS2LGPX34ERwG/dfU9gK+DJLKeYBXRy98Hp52zDgQdDCF/mOXRZD3z88ceYGZtttpkSm0iBxRhZ\ntmwZq1atokePHi0+T16fsbn71sDVwMbATHevcvcX0rsvAPZy9zeBScCJIYQ16eNGuPtYgBDCOuBE\n4Dp3nwccAYzKZ9yy/lizZg3du3dXUhMpAmZG9+7dWbNmTavOk9ceWwhhEZD1X4wQwmLg+w3sm1Bv\n/Tlgt5wHKCIiJaekK4+ItMQ1M+bl5byjDtoxL+ctVuOrxuflvGeWn5mX8xaLFx98Jy/n/faR2+Xl\nvMVItSJFikyfPn3o168f5eXltT9z586lT58+VFVVZT3mrrvuYs8996Rv3764O/vuuy/33HNPG0de\nXLJ9X6eccgpbbbUV5eXl9O/fn5NOOokVK1bU7l+zZg2XXXYZ/fv3Z5dddqGiooJjjjmmwe+9VN17\n770MHDiw9nsaMmQI69atY//992fq1KkArFu3jjPOOIP99tuP+++/nx133LHOd/m3v/2NioqKVt9W\nbAn12ESK0JQpUygvL0/U9qabbuKPf/wj9957LzvvvDMAb7zxBg888EA+Q2y3xowZw8iRI1m1ahVD\nhgzhhhtu4Fe/+hUAp556Kp9//jnPPfcc3bt3B+DRRx/ljTfeSPy/R3v34YcfcvrppzNr1iy23TY1\nIH327Nl1nkOvWbOGk08+mc8//5zp06fTpUsXpk+fzoUXXsj111/PkiVLGD16NP/85z/p1OlrBaXy\nTolNpJ377W9/y0033VSb1AD69evHmDFjChhV8dtwww3ZZ599ePfdVP2HN998k/vuu4/33nuvNqkB\nHHjggYUKsSAWL15MWVlZnVGJe+yxR+3yypUrOeaYY+jevTv33XcfHTum0si4ceOoqKjgySef5Lrr\nruOcc85h1113bfP4QbciRYrS0KFD69yKXLlyZdZ2S5Ys4f3332fQoEFtHGH79+mnn/LEE0/wgx+k\nCsbPmTOHHXbYoVXDzEvBbrvtxj777MO2227Lsccey7hx43j//a9qzp999tlsvPHG3HHHHbVJDaBr\n167ceuutHHfccSxZsoTzzz+/EOEDSmwiRWnKlClUVVXV/nTpkrxYz+DBgxkwYAD9+vXLY4Tt17hx\n49htt93YbLPN2HrrrRk8eHDWdm+//Tbl5eX069ePU089tY2jLJwOHTpwzz338Oyzz3LIIYfwzDPP\nsMsuu/DWW28BcPDBB/P4448zd+7crx279957s/POOzNq1Cg6dChcelFiE2nHevXqxVZbbcWLL75Y\nu23mzJk8+OCDLF68uICRFa8xY8bwyiuvMG/ePEIITJiQeruooqKCt956i08++QSA7bffnqqqKi66\n6KLabeuT/v37M3z4cKZOncp3vvOd2me2P/rRj7juuuv4/ve/n3VQTVlZGWVlZW0dbh1KbCLt3KWX\nXsqoUaN4/fXXa7d98cUXBYyofejduzd/+tOfGDt2LCtXrqRv374cffTRDBs2jGXLviqStL59l++/\n/z7PPPNM7fonn3zC/Pnz2X777Wu3HX/88dxwww0ccsghzJkzpxBhNkqDR0TqKYb3zYYOHVrn9uM1\n11wDpG4DZY4ye/755zn99NPp2rUrJ554Ip9++ik9e/akc+fO/PnPf27zuDMVw/tm9b+v/v371xnd\neNRRR3HNNdcwfvx4zjvvPCZNmsQVV1zBoEGD6NixI927d6dnz55ccMEFbRZzod83q66uZuzYscyf\nP5+NNtqI6upqfvazn3H00UfX/h0C/PCHP6RDhw4ccsghTJs2jYEDBxYw6rosxtKtE1xZWRk1g7Y0\nZvHixWy22WaFDkNEMmT779LdrwkhJPoHXbciRUSkpCixiYhISVFiExGRkqLEJiIiJUWJTURESooS\nm4iIlBS9xyZS38zf5+e8gy9K1KxPnz5suOGGte+xuTu/+c1v+OUvf8n8+fOBVHWHyspK5s2bV1s5\nY+HChXTp0oWePXsCqXffbrvtNmbMmEGvXr34/PPP2WyzzRg+fDgnnXRSHj5gXUv/dENeztvz7LMS\nt129ejWXXHIJ99xzD506daKsrIxRo0YxbNgwAMaOHcvf/vY3ysrKWLVqFUceeSTjxo0DUrUkf/Wr\nXzFjxgw22GADunXrxmWXXcZhhx2Wl89V49m/35mX8+71o58mbnvvvfdyxRVXsHbtWr788ku23HJL\nOnfuzAcffADAyy+/zK677kpZWRndunXj6aefBuCdd95hhx124LLLLuOSSy6pPd+kSZM499xz+a//\n+i+qq6vp2bMnEydOZMcd8/POqBKbSBGqP23NEUccwQEHHFBb1ug///kPK1asYMiQIYwYMQJIzTVW\nXl7OyJEja4+77bbbaqdpAaiqqmLo0KEsXbqU9eEdz1NOOYVVq1bx8ssv07VrVxYsWMChhx7K6tWr\n6dmzJ//4xz946aWX6NKlC9XV1bz22msAxBg57LDDqKioYN68eXTs2JGqqioOP/xwJk2axEEHHVTg\nT5Y/DU1bU1FRUTt1jZnx9NNPs/HGG9c59pZbbmHIkCHceuutXHzxxXWmuhk8eHDtXG7nn38+I0eO\nZNq0aXn5DLoVKdIOLFq0iK222qp2fdNNN6V3797NPk95eTnXXXcdV155JaVcnAFS09BMnTqVG2+8\nka5duwKp3vDVV1/N5ZdfzqJFi+jRowedO3cGoGPHjuy+++4APPbYY7z77rtUVlbWVrAvLy/nv//7\nv7n88ssL84HaSEPT1mQmqWzWrl3LpEmTuP766+nWrRuPP/54g20POOCA2umC8kGJTaQIZU5bc999\n93HBBRcwbNgw9t57b8477zyeeuqpFp970KBBLFmyhKVLl+Yw4uIzZ84c+vbtyyabbFJn+3e/+10+\n/PBDjj32WObPn892223HySefzC233FI7PdDs2bMZOHAgG2ywwdeOnTVrVpt9hkJoatqahkyfPp2t\nt96anXfemWHDhnHzzTdnbbdu3Truu+8+fvzjH+c69FpKbCJFKHPammOPPZYTTjiBhQsXct555wFw\n9NFH1z4Laq5S76kl1b17d+bOncudd97JgAEDGD9+PHvttRerV68udGgF1dS0NQ25+eab+fnPfw7A\nT3/6U6ZNm1ZnVoSZM2dSXl7OpptuyuOPP86ZZ+avlmjeE5u7X+/uC9w9unt5xvYX3L0q/fNqev9u\nDZwjuvvcjPb75jtukWLTvXt3jjvuOK6++mr+8pe/cMcdd7ToPC+99BK9evWiV69eOY6wuFRUVPDm\nm2/y0Ucf1dn+3HPPscsuu/DNb36TsrIy9tprL8aMGcMzzzzD/PnzefXVV9ljjz2YNWsWa9as+dqx\nmbNJl7KGpq3JZunSpTz88MNcfvnl9OnTh4EDB7JmzRruvPOrgTCDBw+mqqqKRYsWseOOO7bvxAbc\nDewD1LmhGkIYFEIoDyGUA78FXg0hvNLIefataR9CeDp/4YoUn4ceeogVK1YAqR7XnDlz6kwjktQr\nr7zCyJEj27RafaH07duXI488ktNPP732u1uwYAEXXHABV199NSEE3n777dr2r7/+OmvWrGGbbbZh\nyJAhbLPNNowaNYrq6mogNfDmiiuu4OKLLy7I52krSaatqe/222/nmGOO4b333mPBggUsWLCAu+++\nO+vtyI022oibbrqJadOm5W3Km7yPigwhPAWpIcuNGAZkvyErIjz55JOMGTOGjh07EmOkX79+3HBD\nsuH048aNY9KkSaxYsYJevXpx0UUXcfLJJ+c54uJw++23c8kllzBgwAA6dOjA/Pnzeeihhzj44IOZ\nPn06Z511FsuWLaNLly6UlZUxefLk2tcl/vGPfzBmzBj69u1bO9x/woQJHHzwwQX+VPnV2LQ1Dbn5\n5pu58sor62w76KCDOOWUU5g9e/bX2m+55Zacf/75XHrppTz44IM5/wxtNm2Nuy8AjgkhVNXbvg3w\nBtA7hPCfBo6NQBWpHuZjwCUhhCZn/9O0NdIUTVuz/li3bh0XXnghM2bM4LHHHqsz6k+KS2unrSmG\n99hOAR5qKKmlbRtCWOjuXYEJwDjgazdo3X00UPvBKyoqchyqiLRXHTp04Kqrrip0GNIGCprY3N2A\nU4EzGmsXQliY/v2Fu48HbmygXSVQWbNeWVmp4V8iIuuZQg/3H0Iquc5oqIG7d3f3jdLLHYChQH6e\nOIqISLvXFsP9J7r7ImBrYLq7Z74MMQy4NYSwrt4xI9x9bHq1P/C8u78MzAU2AUYiIiKSRVuMihze\nyL6fNLB9Qsbyc0DW99tEWqtTp0588sknbLzxxk2WDBKR/IoxsmzZMjp16tSq8yRKbGbWBTgbKAc6\nZwRxXKuuLm3qmhnzErcddVB+qm4Xmx49evDFF1+wePFiJTaRAosx0q1bt9rani2VtMf2v8BnwF7A\n1aRGMra8WJ1IEenatWur/0MSkeKR9Bnb7jHGM4HPYox/AvYHBuYtKhERkRZKmthWpn9Xm1nXGONy\noGeeYhIREWmxpLciPzaz7sA0YLqZ/QdYlL+wREREWiZpYjs8xrjWzC4BfgJ0B27PX1giIiIt02Ri\nM7MyYDpwYEwVlryziUNEREQKpslnbDHGtcBGZlboKiUiIiJNSnor8iXgITP7K/B5zcYYY8Mzz4mI\niBRA0sRWU/njtIxtEVBiExGRopIoscUYB+c7EBERkVxI9NzMzF5Msk1ERKTQkg4IqdOzM7NOQLfc\nhyMiItI6jSY2M7vAzD4BBpjZxzU/pOpGqlakiIgUnaaesU0ApgB/AUZkbP8sxvhJ3qISERFpoUYT\nW4zxU+BTMxsOLIkxfglgZp3NbJsY43ttEaSIiEhSSZ+x3V1v3bJsExERKbikiW2Dmt4aQIxxJbBh\nfkISERFpuaSJLZpZr5oVM9ucVK9NRESkqCStPHI98JyZ3ZFePxG4LD8hiYiItFzSyiO3mtl84LD0\nplNjjE8nOdbdrweOArYFKkIIVentT6S3fZpuelsI4ZoGzjEIuBHoQmoeuJNCCO8nub6IiKxfkvbY\nAJ4B3osxvt3Ma9wNXAX8K8u+USGEqY0d7O4dSE2Vc1oIYaa7nw9cC/yomXGIiMh6IGlJrf2Bd4GZ\n6fU905X+mxRCeCqE0JrZtgcC1SGEmen1icCR7t65FecUEZESlXTwyB+AfYGPAGKMLwEVObj+Ve4+\n192nuPt2DbTpTSqpAhBCWE6q8smWObi+iIiUmKS3IstijG+b1RkIubqV1z4phPCeuxvwS+AhYOfW\nnNDdRwOja9YrKnKRe0VEpD1J2mP70sy+QWoONsxsALCyNRcOIbyX/h1DCDcA27n7JlmaLiQ1yAQA\nd+8GfAv4IMs5K0MIW9f87LTTTq0JUURE2qGkie1y4BFg6/SztRnAxS29qLt3dPfNMtZ/ACwOIXyU\npfksoJO718wJNxx4MITwZZa2IiKynks63P8RM3sTOITUi9m/STo60t0nAocDmwPT3X05sDvwsLtv\nCKwD/kPqlYCaY0YAW4YQLg0hrHP3E4GJ6QEjHwAnJf6EIiKyXmnOcP8lwFxStyP/nfSgEMLwBnZ5\nI8dMqLf+HLBb0muKiMj6K1FiM7MDgMnA+6R6bFuY2QkxxpmNHykiItK2kvbYrgWOijG+AGBm3wZu\nBgbkKzAREZGWSDp4ZF1NUgOIMb4IrM1PSCIiIi2XNLE9Yman2FdOJjVKUkREpKgkvRX5C1Lvjk1M\nr3ciNbP2aUCMMfbIR3AiIiLNlTSxlec1ChERkRxJ+h7buwBm1hHYlVSV/2wvU4uIiBRUo8/YzOzK\ndPkszKwz8AKpCv8LzOyINohPRESkWZoaPHIk8Fp6+QRSVUI2A/YBLs1jXCIiIi3SVGJbFWNcl17e\nH7grxrg6xvgyzataIiIi0iaaSmwdzWyD9PI+pGbRrqGJPkVEpOg01ev6OzDTzD4GviT1jA0z2w74\nNM+xiYiINFujiS3GONbMXgO2JnUbMqZ3dQd+k+/gREREmqvJ52QxxnuybJuVn3BERERaJ2lJLRER\nkXZBiU1EREqKEpuIiJSURp+xmdl+je2PMT6V23BERERap6nBI1enf5eRKoT8DhCB7YEqYI/8hSYi\nItJ8jd6KjDHuGWPck1QSOzjGuEOMsS/wfWB2WwQoIiLSHEmfsXmMcUbNSozxUWDP/IQkIiLScknr\nPa41s8ExxpkAZvY9UgWRm+Tu1wNHAdsCFSGEqvT2W4G9gZXA58DIEMJLDZwjAq8Ca9Obzg4hPJ0w\ndhERWY8kTWy/BO4yszUZxw1NeOzdwFXAv+ptvw84LYRQ7e5HkCrf1aeR8+wbQliW8JoiIrKeSjrR\n6LNmtj3QP73p9RjjmsaOqRFCeArA3etvfyBj9XlgK3fvGEKoTnJeERGRbJoz9cxRQL8Y4/+Y2ZZm\ntkmMcW6O4jgXmNZEUpvp7h2Ax4BLQghf5OjaIiJSQhIlNjMbS2qwyPbA/5Aa8j8R2Ku1Abj7icDx\nQGPvzG0bQljo7l2BCcA44Mws5xoNjK5Zr6ioaG14IiLSziTtsR1N6p21ABBj/NDMvtHai7v7UFKz\nBBwQQljcULsQwsL07y/cfTxwYwPtKoHKmvXKysqYrZ2IiJSupMP9V8YY19bbZq25sLsfD/wOOLAm\ncTXQrru7b5Re7kBq0Mqc1lxbRERKV9Ie27tmti8QzawT8GtSL203yd0nAocDmwPT3X15CGEH4E7g\n38D9GQNLDgghfOTuI4AtQwiXkhqwMjE95L8jqRfDz00Yt4iIrGeSJrZzgNuAAcAXwEzgxCQHhhCG\nN7C9UyPHTMhYfg7YLWGcIiKynks63H8xcIiZbQRYjFEjEkVEpCglHRX5Yozx2zHGFfW35S80KVXX\nzJiXl/OOOmjHvJxXRNqXpINH6iTA9HO2brkPR0REpHUaTWxmdoGZfQIMMLOPa36AzwDNxSYiIkWn\nqVuRE4ApwF+AERnbP4sxfpK3qERERFqo0cQWY/wU+BQ4tG3CERERaZ2kg0d6AZcBuwOda7bHGDWD\ntoiIFJWkg0duBhYAm5IqgfUB8HCeYhIREWmxpIltmxjjlcCqGOODwHHAgfkLS0REpGWSJrbV6d9f\nmtkmQDWp3puIiEhRSVpSa146of0VeIHUcP9ZeYtKRESkhZKW1KqpC3mdmc0CNgb+mbeoREREWqg5\nM2gDEGP8Vz4CERERyYVGE1u66ki2yToNiDHGHnmJSkREpIWa6rGVt0kUIiIiOdJU5ZF32yoQERGR\nXEhaeWQ+WW5Jxhi3y3lEIiIirZB08MgRGcudgZOAj3IfjoiISOskHe7/Wr1Ns8zsWeDy3IckIiLS\nckkrj9SRfll78xzHIiIi0mpJn7HN4atnbGXAtsBV+QpKRESkpZI+YxuZsVwNvBNj/DDJge5+PXAU\nqWRYEUKoSm/vBdwObA+sAs4MIWSdldvdBwE3Al2ARcBJIYT3E8YuIiLrkUS3ImOMT2b8PJM0qaXd\nDewD1H914A/A8yGEvsCpwGR371T/YHfvANwJjAwh7AhMA65txvVFRGQ9kiixmdnOZjbFzGab2Ss1\nP0mODSE8FUJYlGXX8cCEdJuXSM3x9r0s7QYC1SGEmen1icCR7t45S1sREVnPJb0VeRep24Z/Bta2\n9qLuvgnQKYTw74zNC4DeWZr3JqO3F0JY7u6fAVsC79Q772hgdM16RUVFa0OVBK6ZMa/QIYiI1Eqa\n2NbGGP+Y10hyIIRQCVTWrFdWVmarcykiIiUs6XD/mWa2X64uGkL4CKh298xXBvoAC7M0X0hq4AkA\n7t4N+BapW5ciIiJ1JE1sdwMPm9kHZvaOmc03s3eaPKpxfwdGALj7nsBWwJNZ2s0COrn74PT6cODB\nEMKXrby+iIiUoKS3Im8FzgUCzXzG5u4TgcNJvdA93d2XhxB2AC4A7nD3N4HVwIkhhDXpY0YAW4YQ\nLg0hrHP3E4GJ6QEjH5Aq6SUiIvI1SRPb5zHGW1pygRDC8Aa2Lwa+38C+CfXWnwN2a8n1RURk/ZL0\nVuTDZnZkXiMRERHJgaQ9trOBb5nZSlJVQjSDtoiIFKWkiU0zaYuISLuQdNoazaQtIiLtQqOJzcz+\nvxjjCfWq+9eKMe6Rt8hERERaoKkeW021kZGNthIRESkSjSa2GOOs9O/aF6fNbOMY47J8ByYiItIS\njQ73N7ORZrZTermDmT0IfGxmS83su20SoYiISDM09R7bL4C308s/AnYAtgBOAa7MX1giIiIt01Ri\nq44xrk4vHwDcEWNcHGN8GOiW39BERESar6nE1tHMLL28N/Bsxr6vzXYtIiJSaE2NinwMmGJmS0j1\n0P4FYGabk6pAIiIiUlSa6rGdB7wArAEOiTFWp7f3JWNCTxERkWLR1HD/auDqLNufzltEIiIirZC0\nur+IiEi7oMQmIiIlpakXtA9K//5m24QjIiLSOk312P6Q/v1EnuMQERHJiaaG+3cyswuAXmZ2Tv2d\nMcbr8xNW23vxwXea1f7bR26Xp0hERKQ1mkpspwE/A7oAFfX2fW0aGxERkUJrarj/C8ALZvZujDGn\ntSHdfRNSL4DX2AjYDugVQvg4o10fUvUq52a0/UEI4W1ERETqSTqD9pVm9m3gwPSmR2KMoTUXDiF8\nBJTXrLv7+cD3MpNahuUhhPIs20VEROpINNzfzE4H7gZ6AT2Be8zsFzmOZRhwc47PKSIi65lEPTbg\nLGBgjHEpgJn9D6nbiDflIgh33wvoDjzUQJOu7j4LMGAqcEUIYW0uri0iIqUlaWKjJqnVLH9V9D8n\nhgG3hxCqs+z7ENgqhLDE3XsAU0jVsLyqfkN3Hw2MrlmvqKg/3kVEREpd0sT2ppldAUxMr58GvJmL\nANz9G8DxwJ7Z9ocQVgFL0ssfu/stwE/IkthCCJVkFGeurKzUyE0RkfVM0pJaI4DtgdnALFIzaZ+R\noxiGAi+HEF7PttPde7l7p/TyhsBxwJwcXVtEREpM0lGRS4Ef5ymGYcD/Zm5w97HAByGECcA+wFh3\nX0sq3seBK/IUi4iItHOJn7HlSwhhryzbLs1Yvhe4t02DEhGRdkvV/UVEpKQUvMcmrTO+anwzWh/Y\ndJO0a2bMa34wIiJFoMkem5mVmdmjbRGMiIhIazWZ2GKMa4GNzEy3LUVEpOglvRX5EvCQmf0V+Lxm\nY4zxgbxEJSIi0kJJE9tu6d+nZWyLgBKbiIgUlaTvsQ3OdyAiIiK5kLS6f0czO8/MxqfXtzezIfkN\nTUREpPmS3oq8ASgjVQUE4CNSxYg9H0GJiIi0VNLE9p0YY7mZzQGIMS4zs055jEtERKRFkg7h/zJz\nxczKmnGsiIhIm0manF4xsxOBDma2AzABeCJvUYmIiLRQ0sQ2GtgX2Bx4FlgHXJCvoERERFoq6XD/\nz4Hh6R+RotSc+pajDtoxj5GISCElSmxmtiEwilQV3QjMAK6LMa7KY2wiIiLNlnRU5ARgE+BP6fVT\ngf7Az/MRlIiISEslTWzfBXaKMUYAM3sIeC1vUYmIiLRQ0sEjHwFdMtY3BP6T+3BERERap9Eem5md\nk158HXjBzP6WXv8hqYr/IiIiRaWpW5EVGcsB2C69PJtUiS0REZGi0mhiizGe2laBiIiI5ELSwSOY\n2aFA38xjYoyVrbm4uy8AVgEr05t+H0KYkqXdEcAfSfUS5wKnhBA+a821RUSkNCV9j20ysBMwB1ib\n3hxzFMPQEEJVQzvd/RvAzcD3Qgivu/sNwCXAmBxdX0RESkjSHtsewC4xxrVNtsy9Q4E5IYTX0+vj\ngUdQYhMRkSySDvdfQGqIfz7c4e5z3f1md++ZZX9v4N16sWzh7olvo4qIyPojaXI4D3jUzJ4gYwqb\nGOPYVl5/vxDCQnfvBPwOuA04rKUnc/fRpAo2A1BRUdFIa1mfNaeuJKi2pEh7kjSx/R5YDXQGcjbB\naAhhYfr3Gne/Fsj2r81C4KCM9T7AhyGE6iznqwRqB7RUVlbm6jmgiIi0E0kTW78YY79cXtjduwKd\nQgjL0ptOIDU4pb5/An929/7p52xnAnflMhYRESkdSRPbG2b2zRhjLofYbwbc4+5lgAHvACcDuPtY\n4IMQwoQQwnJ3/wUwNf1c7VXgZzmMQ0RESkjSxLYSmG1mj1D3Gdvohg9pXAjhHepWNsncd2m99QeA\nB1p6LRERWX8kTWz/l/4REREpakln0L4s34GIiIjkQtLKI5dm256D4f4iIiI5lfRWZLeM5c6k3jV7\nLvfhiIhJgQAgAAAJLElEQVSItE7SW5F1yleZ2W+BSXmIR0REpFWSltSqI8b4EV/NzSYiIlI0kj5j\nOydjtQz4NvDvvEQkIiLSCkmfsWW+b1YNVAE35j4cERGR1kn6jE0zaYuISLvQaGIzs/0a2x9jfCq3\n4YiIiLROUz22q7Nsi8CWwBaknreJiIgUjUYTW4xxz8x1M+sBXAycCPwmj3GJiIi0SKLh/mbW2cwu\n4qt6kTvFGH+Xv7BERERaptHEZmYdzOx04E2gPzAoxjg6/R6biIhI0WnqGdurwIbAr4GXgW+Z2W41\nO2OMr+QxNhERkWZrKrFtRGqwSLZixxFVHxERkSLT1OCRPm0Uh4iISE60qFakiIhIsUpaUqvkvfvy\ntGa1//aRZ+UpkvyZ/dmUxG33+ObQPEYiIpI/6rGJiEhJKViPzd07A3cBOwMrgSXAGSGEt+q16wO8\nDczN2PyDEMLbbRSqiIi0I4W+FXkj8I8QQnT3s4CbgP2ztFseQihv08hERKRdKlhiCyF8CWQ+2Hoe\nOL9A4YiISIkodI8t07nA/Q3s6+ruswADpgJXhBDWtllkIiLSbhRFYnP3XwM7AAdk2f0hsFUIYYm7\n9wCmAOcBV2U5z2hgdM16RUVF/SYiIlLiCp7Y3P184DjgwBDCivr7QwirSA0sIYTwsbvfAvyELIkt\nhFAJVNasV1ZWxnzFLSIixamgw/3TPawTgINCCMsaaNPL3TullzcklQTntF2UIiLSnhQssbn71qQm\nMt0YmOnuVe7+QnrfWHcfkW66DzDH3V8GZgP/Bq4oRMwiIlL8CjkqchGpwSDZ9l2asXwvcG9bxSUi\nIu2bKo+IiEhJKfjgkaKxbGGhIygqqispIu2VemwiIlJSlNhERKSkKLGJiEhJUWITEZGSosQmIiIl\nRYlNRERKihKbiIiUFCU2EREpKUpsIiJSUpTYRESkpCixiYhISVGtyHauz99fSNz2uT12yEsMzakr\nCe2ztuTSP92Ql/P2PPusvJxX1j/N+Rttzt9dc//2i+FvWj02EREpKUpsIiJSUpTYRESkpCixiYhI\nSVFiExGRkqLEJiIiJUWJTURESkpB32Nz977AbcCmwKfAKSGE17K0OwL4I1AGzE23+6wtYxURkfah\n0D22icCNIYQdgSuBSfUbuPs3gJuBY0IIfYEPgEvaMkgREWk/CpbY3L0X4MBf05vuAbZx9/rlMQ4F\n5oQQXk+vjwdOaJsoRUSkvSlkj20b4MMQQjVACCECC4He9dr1Bt7NWF8AbOHuKgcmIiJfU1LJwd1H\nA6MzNs2dPHnyo6087R7A7Pobr3Rv5WkLYPrXHl+2lTrf4f/P/YWKo8XuzNeJb5vUnNZZ/xalWfQd\nQnP/7rJp+Hts/bkbsm3ShoVMbO+R7nmFEKrd3Uj1zhbWa7cQOChjvQ8ZPb1MIYRKoDKXQbr7ohDC\n/rk85/pG32Fu6HtsPX2HuVHs32PBbkWGEJaQyvgnpjf9AFgUQnirXtN/Anu4e//0+pnAXW0TpYiI\ntDeFHhU5HBju7vOAC4FTAdx9rLuPAAghLAd+AUx197eArYHLCxSviIgUuYI+YwshvAF8N8v2S+ut\nPwA80FZx1ZPTW5vrKX2HuaHvsfX0HeZGUX+PFmMsdAwiIiI5U+hbkSIiIjmlxCYiIiWlpN5jy6Wk\ndSylYe5+PXAUqfdPKkIIVQUOqd1x986kRgHvDKwElgBnZBk9LE1w90eAzYF1wHLgnBDCnMJG1T65\n+6nALcCxIYSphY6nPvXYGtZkHUtp0t3APtStHCPNdyPQL4SwO3A/cFOB42mvjg8h7BZCKCc1+GFS\ngeNpl9y9D3Aa8HyBQ2mQElsWzahjKY0IITwVQlhU6DjasxDClyGEaemSc5D6x6RPAUNqt0IIyzJW\nvwVo5FwzuXsHUv/H6mxgVYHDaZASW3ZJ61iKtLVzoR3WJCsS7n67u79H6l3YkwodTzs0GngmhDCr\n0IE0Rs/YRNoJd/81sANwQKFjaa9CCCcDuPvPSD1iOKywEbUf7r4rqQpR+xU6lqaox5ZdbR1LgEbq\nWIq0CXc/HzgOODSEsKLQ8bR3IYTbgMHuvkmhY2lH9iV1G/xNd18AfAe40d3PKGRQ2ajHlkUIYYm7\n19SxnETDdSxF8i49a8UJwIH1nhNJQu6+MbBRCOGD9PoxwEfAxwUNrB0JIfwF+EvNurs/AVxbjKMi\nldgaNhyYlL798xnpOpaSnLtPBA4nNcR6ursvDyFoAE4zuPvWwNXAO8BMT02XtCqEMKiggbU/3wL+\n7u5dSA33XwockTEoR0qISmqJiEhJ0TM2EREpKUpsIiJSUpTYRESkpCixiYhISVFiExGRkqLEJtJG\nzGyBmb1hZlXp3xe24BxHmNkTTbT5rZld28C+o8zsmoz1y8zsdTN7wcz6mNmI5sYkUmz0HptI2xoa\nY6wys62A/zOzx2OML7bVxWOMDwAPZGz6FbBdjPFDM9sfGAFMaKt4RPJBPTaRAogxvg+8TmquOszs\npHSvabaZPWVmu6e3dzKz8Wb2ppm9CAyuOYeZ9TWzZ8zsZTOba2a/y7jEFmb2oJn9n5k9bmY90sec\nYmZT08vPAp2BR8zselIJrV+6R5mZ/ETaFfXYRArAzPoDmwBPmNnepEpm7RdjXGVm+wKTgV2A04F+\n6WWA6RmnOQt4KMb4+/Q5e2TsGwQMjDF+ZGZ3kaqk8/vMGGKMe5lZBPaNMS5L99iujTGW5/jjirQp\nJTaRtjXFzNaRSlajYoxLzWwMsDvwgpnVtOthZl1IVfK/Pca4GsDMbgGGpds8BYwzs28ATwKPZlzn\nnzHGj9LLzwED8vmhRIqJbkWKtK2hMcadgO8DfzCzAYABt8UYyzN+togxrsxyfG0NvBjjPcDewBuk\ne28Z7b7MWF6L/k+srEeU2EQKIMb4KKlK6b8jNZjjRDPrDWBmHczM000fTe/rZGYbkFGM28z6Aotj\njLeTGgTynVaG9RmpYsEi7ZoSm0jhXA7sA6wglZjuM7OXgdeAH6fb/C/wJvB/wL+AqozjfwjMNbM5\nwBRSIxpb4xXgNTN7VYNHpD1TdX8RESkp6rGJiEhJUWITEZGSosQmIiIlRYlNRERKihKbiIiUFCU2\nEREpKUpsIiJSUpTYRESkpCixiYhISfl/eSSjG4+K/fcAAAAASUVORK5CYII=\n",
       "text/plain": [
-       "<matplotlib.figure.Figure at 0x11691dfd0>"
+       "<matplotlib.figure.Figure at 0x111c5cc18>"
       ]
      },
      "metadata": {},
@@ -522,22 +579,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
-   "metadata": {},
+   "execution_count": 17,
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "INFO:quickgen.py:242:main: Reading fibermap file /Users/ioannis/research/projects/desi/spectro/sim/example/20170615/fibermap-00000000.fits\n",
-      "INFO:quickgen.py:275:main: Initializing SpecSim with config desi\n",
-      "INFO:quickgen.py:281:main: Reading input file /Users/ioannis/research/projects/desi/spectro/sim/example/20170615/simspec-00000000.fits\n",
-      "INFO:quickgen.py:672:main: Writing files for channel:b, spectrograph:0, spectra:0 to 100\n",
-      "INFO:quickgen.py:699:main: Wrote file /Users/ioannis/research/projects/desi/spectro/redux/example/exposures/20170615/00000000/frame-b0-00000000.fits\n",
-      "INFO:quickgen.py:717:main: Wrote file /Users/ioannis/research/projects/desi/spectro/redux/example/exposures/20170615/00000000/cframe-b0-00000000.fits\n",
-      "INFO:quickgen.py:732:main: Wrote file /Users/ioannis/research/projects/desi/spectro/redux/example/exposures/20170615/00000000/sky-b0-00000000.fits\n",
-      "INFO:quickgen.py:753:main: Wrote file /Users/ioannis/research/projects/desi/spectro/redux/example/exposures/20170615/00000000/calib-b0-00000000.fits\n",
-      "INFO:quickgen.py:672:main: Writing files for channel:r, spectrograph:0, spectra:0 to 100\n"
+      "WARNING:quickgen.py:175:parse: deriving fibermap /data/desi/spectro/sim/example/20170615/fibermap-00000000.fits from simspec input filename\n",
+      "INFO:quickgen.py:239:main: Reading fibermap file /data/desi/spectro/sim/example/20170615/fibermap-00000000.fits\n",
+      "DEBUG:simexp.py:517:get_source_types: elg 69 targets\n",
+      "DEBUG:simexp.py:517:get_source_types: lrg 13 targets\n",
+      "DEBUG:simexp.py:517:get_source_types: qso 8 targets\n",
+      "DEBUG:simexp.py:517:get_source_types: sky 8 targets\n",
+      "DEBUG:simexp.py:517:get_source_types: star 2 targets\n",
+      "INFO:quickgen.py:272:main: Initializing SpecSim with config desi\n",
+      "DEBUG:specsim.py:39:get_simulator: Creating new desi Simulator\n",
+      "WARNING:specsim.py:47:get_simulator: Treating BGS fiberloss = 0.5 * LRG fiberloss\n",
+      "INFO:quickgen.py:278:main: Reading input file /data/desi/spectro/sim/example/20170615/simspec-00000000.fits\n",
+      "INFO:quickgen.py:677:main: Writing files for channel:b, spectrograph:0, spectra:0 to 100\n",
+      "INFO:quickgen.py:704:main: Wrote file /data/desi/spectro/redux/example/exposures/20170615/00000000/frame-b0-00000000.fits\n",
+      "INFO:quickgen.py:722:main: Wrote file /data/desi/spectro/redux/example/exposures/20170615/00000000/cframe-b0-00000000.fits\n",
+      "INFO:quickgen.py:737:main: Wrote file /data/desi/spectro/redux/example/exposures/20170615/00000000/sky-b0-00000000.fits\n",
+      "INFO:quickgen.py:758:main: Wrote file /data/desi/spectro/redux/example/exposures/20170615/00000000/calib-b0-00000000.fits\n",
+      "INFO:quickgen.py:677:main: Writing files for channel:r, spectrograph:0, spectra:0 to 100\n"
      ]
     },
     {
@@ -551,23 +618,20 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "INFO:quickgen.py:699:main: Wrote file /Users/ioannis/research/projects/desi/spectro/redux/example/exposures/20170615/00000000/frame-r0-00000000.fits\n",
-      "INFO:quickgen.py:717:main: Wrote file /Users/ioannis/research/projects/desi/spectro/redux/example/exposures/20170615/00000000/cframe-r0-00000000.fits\n",
-      "INFO:quickgen.py:732:main: Wrote file /Users/ioannis/research/projects/desi/spectro/redux/example/exposures/20170615/00000000/sky-r0-00000000.fits\n",
-      "INFO:quickgen.py:753:main: Wrote file /Users/ioannis/research/projects/desi/spectro/redux/example/exposures/20170615/00000000/calib-r0-00000000.fits\n",
-      "INFO:quickgen.py:672:main: Writing files for channel:z, spectrograph:0, spectra:0 to 100\n",
-      "INFO:quickgen.py:699:main: Wrote file /Users/ioannis/research/projects/desi/spectro/redux/example/exposures/20170615/00000000/frame-z0-00000000.fits\n",
-      "INFO:quickgen.py:717:main: Wrote file /Users/ioannis/research/projects/desi/spectro/redux/example/exposures/20170615/00000000/cframe-z0-00000000.fits\n",
-      "INFO:quickgen.py:732:main: Wrote file /Users/ioannis/research/projects/desi/spectro/redux/example/exposures/20170615/00000000/sky-z0-00000000.fits\n",
-      "INFO:quickgen.py:753:main: Wrote file /Users/ioannis/research/projects/desi/spectro/redux/example/exposures/20170615/00000000/calib-z0-00000000.fits\n"
+      "INFO:quickgen.py:704:main: Wrote file /data/desi/spectro/redux/example/exposures/20170615/00000000/frame-r0-00000000.fits\n",
+      "INFO:quickgen.py:722:main: Wrote file /data/desi/spectro/redux/example/exposures/20170615/00000000/cframe-r0-00000000.fits\n",
+      "INFO:quickgen.py:737:main: Wrote file /data/desi/spectro/redux/example/exposures/20170615/00000000/sky-r0-00000000.fits\n",
+      "INFO:quickgen.py:758:main: Wrote file /data/desi/spectro/redux/example/exposures/20170615/00000000/calib-r0-00000000.fits\n",
+      "INFO:quickgen.py:677:main: Writing files for channel:z, spectrograph:0, spectra:0 to 100\n",
+      "INFO:quickgen.py:704:main: Wrote file /data/desi/spectro/redux/example/exposures/20170615/00000000/frame-z0-00000000.fits\n",
+      "INFO:quickgen.py:722:main: Wrote file /data/desi/spectro/redux/example/exposures/20170615/00000000/cframe-z0-00000000.fits\n",
+      "INFO:quickgen.py:737:main: Wrote file /data/desi/spectro/redux/example/exposures/20170615/00000000/sky-z0-00000000.fits\n",
+      "INFO:quickgen.py:758:main: Wrote file /data/desi/spectro/redux/example/exposures/20170615/00000000/calib-z0-00000000.fits\n"
      ]
     }
    ],
    "source": [
-    "args = quickgen.parse([\n",
-    "    '--simspec', simspecfile,\n",
-    "    '--fibermap', fiberfile\n",
-    "])\n",
+    "args = quickgen.parse(['--simspec', simspecfile])\n",
     "quickgen.main(args)"
    ]
   },
@@ -582,14 +646,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
-   "metadata": {},
+   "execution_count": 18,
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Reading /Users/ioannis/research/projects/desi/spectro/redux/example/exposures/20170615/00000000/cframe-b0-00000000.fits\n"
+      "Reading /data/desi/spectro/redux/example/exposures/20170615/00000000/cframe-b0-00000000.fits\n"
      ]
     }
    ],
@@ -601,8 +667,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
-   "metadata": {},
+   "execution_count": 19,
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [
     {
      "data": {
@@ -649,7 +717,7 @@
        " 'wave']"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -667,8 +735,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
-   "metadata": {},
+   "execution_count": 20,
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -684,24 +754,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
-   "metadata": {},
+   "execution_count": 21,
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<matplotlib.text.Text at 0x11beed128>"
+       "<matplotlib.text.Text at 0x11a47fa20>"
       ]
      },
-     "execution_count": 20,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     },
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAZEAAAEKCAYAAADTgGjXAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAIABJREFUeJzt3XmYHHd95/H3d3oujTS6kGzLOpAgXDI2AiQbcYUjYMDs\nGhJAELIhibMWWQKbkBDMkgSFhABJCNlsApEhXFkIcgAHHuzFxIQ8ecDCtnzKljkMkrHksSUjSzPS\naEbT09/9o6p6qmuqe6p7+pz+vJ5nnumurq7+VR+/b/1uc3dERERq0dPqBIiISOdSEBERkZopiIiI\nSM0UREREpGYKIiIiUjMFERERqZmCiIiI1ExBREREaqYgIiIiNettdQIaadWqVb5x48ZWJ0NEpKPc\ndtttj7r76iz7LuggsnHjRvbt29fqZIiIdBQzeyDrvqrOEhGRmimIiIhIzRRERESkZgoiIiJSMwUR\nERGpmYKIiIjUTEFERERqpiAiIiI1UxApY8fuvezYvbfVyRARaWttF0TM7FNmdtTM7olt22VmR8zs\nzvDvVa1Mo4iIBNouiACfAV6Rsv2j7r4l/Lu+yWkSEZEUbRdE3P0/geOtToeIiMyt7YJIBW83s7vD\n6q4VrU6MiIh0ThD5OPAEYAswAnyk3I5mdqWZ7TOzfceOHWtW+kREulJHBBF3f8Tdp929AHwCuLjC\nvle7+1Z337p6dabp8EVEpEYdEUTMbE3s7muBe8rtKyIizdN2i1KZ2T8DLwJWmdlh4H3Ai8xsC+DA\nIWBnyxIoIiJFbRdE3P1NKZv/sekJERGROXVEdZaIiLQnBRERkQRNe5SdgoiIiNRMQURERGqmICIi\nIjVTEBERkZopiIiISM0UREREpGYKIiIiUjMFkSqp/7iIyAwFERERqZmCiIiI1KztJmBsFwdGRlud\nBBGRtqeSiIiI1ExBREREaqYgIiIiNVMQERGRmimIiIhIzRREUuzYvZfxyXyrkyEi0vYUREREpGYK\nIiIiUjMFERERqZlGrKdwdwoOBfdWJ0VEWkAzVmSnkkiKE2emcGByqtDqpIiItDUFkRRRASRfUElE\nRKSStgsiZvYpMztqZvfEtq00s38zsx+F/1e0Mo0iIhJouyACfAZ4RWLbVcC33P1JwLfC+yIi0mJt\nF0Tc/T+B44nNlwOfDW9/FnhNI9NgjTy4iMgC0nZBpIxz3X0kvP0wcG4zX1xL4oqIpOu4Lr7u7mZW\ntsXbzK4ErgTYsGFDXV5T3f1EpN1FF7p7dm5v6ut2SknkETNbAxD+P1puR3e/2t23uvvW1atXNy2B\nIiLdqFOCyNeAt4S33wJ8tYVpqYmqxEQ6x/hkXpOwZtR21Vlm9s/Ai4BVZnYYeB/wIeAaM7sCeAB4\nQ6vSd3Rsgqnp0tq0ZHBodnFSRKRV2i6IuPubyjz00qYmpIyDj44Xb6tkISLtolVtt51SndW2DoyM\nquFdRLpWTSURM1sMTLj7dJ3T0x5SBoqMT+ZLSh4qhYgsXJ0492qr2nAylUTMrMfMftnMrjOzo8D3\ngREzO2Bmf2lmP9fYZHYWNaKLdDYHCsDBR0+3OilVa3b+k7U669vAE4H3AOe5+3p3Pwd4PvA94MNm\n9isNSmNLKRiIdJ+oIDJy4kxL09EJslZn/YK7TyU3uvtx4MvAl82sr64payPjk3mmO7B4KyLdZdqD\ndtrNa5Y27TUzlUTSAkgt+3SKB4+Pl9xXABERSTdnEDGzl5nZJ8xsS3j/ysYnq3Opt5aIdJMs1Vm/\nAfwW8IdmthLY0tgktZd4QNh3KDm5sIgsZKqEmFuW6qwxdz/h7r8PvBzY1uA0tS1Va4l0l07s6tts\nWYLIddENd78K+FzjkiMiIvMxNpFvapX6nNVZ7l6c7NDMtgIvMbNfD59rwS5+UeOS2FqVBvAcGBll\nfDLP0ECv2kFEFiBXhdacqh2x/nngXcB+grE4QhD5AYYHy7+d42fzDPbmmpUkEekyrapurzaIHHP3\nrzUkJW1kcqq+8fHY2CT7j4yyakl/XY8rItJq1QaR95nZJ4FvAZPRRnf/Sl1T1QGqqb46FVaJRSUW\nEZGFotog8uvAU4E+ZqqzHFiwQaQeRUSvootHq5a4FJHZ1DtrbtUGkW3u/pSGpGSBOTAyyo7de0uC\nQcrkwEWao0tE6iWadbwZF6PVridyk5ltbkhKOlS8pFJwZ7qgSxeRhaJTf83NbGSvNog8B7jTzH5g\nZneb2X4zu7sRCWulLO9/Wtff05PTjJ+dWWIlKo106hdRRGQu1VZnvaIhqWgz8830T03kMWBxmS6/\navcQkflqlyrwqoKIuz/QqIQsJM5MIDowMsrvfvHOOZ8T9fZq5hTOIlJZNZ1iWqmVg52rqs4ys8+a\n2fLY/RVm9qn6J6v9TTvkpyuPJ5lV5VWpZT3cP/5lqOcKZVptUUQaodo2kYvc/UR0x90fA55Z3yR1\njjMZByX++NgpACbzBXbs3suBkVH2HTpezNR37N7bsvWRRaS8ziiHtFa1bSI9ZrYiDB6EU8NXe4yu\ncybW2C4iUg/R0hRDA70tvQitNgB8BPiemV0T3n898IH6JmnhmqM2q+XU4C+ycDSrnSRTdZaZbTcz\nc/fPAa8FHgn/ftHd/6mRCVwIokqvRg8hKdfuEVWhiYjUW9aSyK8Cf29mPwS+AXzJ3R9uXLLKM7ND\nwBgwDeTdfWsr0jFf055+peDujJ6ZKmb8tfTWUolCpD7avfagHWQqibj7b7n7s4BdwArgM2a218z+\n3MxeaGbNnuP8xe6+pVMDSBr34G8yX+C+h8eK7SjRgMW5qLQhIq1Q7TiR7wPfBz5qZouAFxO0i/w1\nsGAy9HrJMvXAjt172X/kJAWCq55o2pR8IVvPL3XbFZFWqrlnlbufAa4P/5rJgRvNbBrY7e5X1/sF\njMZ07espUzaOBjQ5M8XnQz8bZ3JqmqEBdX4TkfZV7WDD15vZcHj7j8zsK2bW7HEiz3f3LcArgbeZ\n2QsTabzSzPaZ2b5jx441OWnZJLvjxRfBihrfJ8LqrOQAxFqdzRe4+eBxJqaa091YgxtlITBTq8hc\nqh1s+EfuPmZmzwdeCvwj8A/1T1Z57n4k/H8UuBa4OPH41e6+1d23rl69uplJm1MUIOoxw2a1mfTZ\nfBCoRiemyh5PbSoinWHH7r0tWw43qdogEl3GXgZc7e7XAU1b89XMFsdKQouBlwP3NOv1azHXIKAD\nI6NlF6uf9soB58DIaF0z/rP5Aj98ZAxQSUKknUW/+2mHQsEbPnygkmor3I+Y2W7gZcCHzWyA6gPR\nfJwLXBsWMXuBL7j7N5r4+vMWz/THJ/Nl2zzigSW+Rsl8M/adn7uN+4+dYvOapbO6AE/mC0zmZ145\nbWEtEWkvp1s8I0ZVgw2BNwA3AJeGc2itBN7VwPSVcPefuPszwr8L3L3tR8snJwGNl0yyFkcnKnxJ\n4m0mU9OFYrVV3MjJiZKOAuOT+ZK5u0SkNiqxVznYEIgGG44BuPsIMNKYpC0MySw9GVROT8w9502B\nmRLIgZHRkhLMtMPYRJ57HzrJxFShOEDxvlgp4qfHxyseP9ke0qj2EQ2CFFl4MgURd/8tADN7KkGv\nqM+Y2TLg2wRB5bvurlkGM0gGlWyjQWaMT+YrlmAm8wXuOnyCggdtHLVcJcUndovER9CXCwLRa/35\nL17IzQeP87Q1w1W/tkgnaXZnlOg31k6zfmuwYYeYawqU8cmZGB6Vdu548ESZvWeOmRZkqu31kTzG\nd370KAD3Hz3VlDYVlXCkUdqlg287V5lVFUTM7J0pm+8k6OorDXZgZLRsBt+qzhlpc3xVsxqcAoBI\nqUq/iaiWoJ1U27NqK/BWYG34t5Ng3fWrzewP6pw2SRiLtZ+MT+bLFmkrZeE/PDpW7Docb5SfTBmE\nOF3wzHN3ZX19kU6QKze9RAsk2yjn6vofaVaVV7VdfNcBz3L3UwBm9j7gOuDngduAv6hv8qSceg80\nOptywPGz0wwPln5FDoyMcuGuG8oe58DIKA+fnJi1fcfuvdz70Mni7UaUPJLBTqUbkcarNoicA0zG\n7k8B57r7GTObLPMcqYOxOXpx1RJTstQ6nZ4IugNHjezR1U3yfpa0TEwVyLdyVJRIlTTrydyqrc76\nPHCzmb0vLIV8F/hCOHr8QN1TJ3WXHEcyPpkvlhDSFAhKPWfOTlOIRZ206rSo+/Ejo0FJJBkvGhVA\nCu7BWJhY+ipVw7VL3/4s6WiXtErzlJuJolKbaJoqmibnJXMQCQcbfga4EjgR/r3V3d/v7qfd/c2N\nSaLU01TsWxgFiFOTc/fOzhecianCrC9mVD97YGSUqelCsWsxBG0qdx0+MSsTjGfwZ/MFToyfLfu6\nWTLRh09O8NPj4zwyOlk8floJqZEZsjJ7qZdCwTk9kZ/396na4QO1ylyd5e5uZte7+4XAvgamSdpU\nNP1K2gpkk/n00fKFsHE+KQok9zx0siSwzSdd03OUdKJ0VOoqHf/hVhoXk2XcTDO1ay+3dk1XO4re\nq9OxBemi/6cn8vT1NnOGqeyqbRO53cy2ufutDUmNdIQoz49/pdMCCAQN9tOF0jnC4qWEeADJ2jBe\nLgOfnC4wMTXN2EQ+c//+emRy1S5lXM0VpmZWbm/VdGePq+Z7d3oiTwFK5rVrJ9UGkUuAN5vZA8Bp\nwvWb3P2iuqdM2l7Wr7Q7nE6ZMyw51UokmXFWmghyx+69jIS9wY6NTXJsLKjScuBUhc4I8Sq1aiaa\nrKWKId5FMx5oxiby9OXKh7uxiSnGJvIM9jXnCrRcxlZLoI2e04xMtpWiziLuXvPaIxfuuqE4lVHa\nhUh7ho4Z1QaRSxuSClnQnLkb+dIy2R2793L34RPFOcGqde/IKBf88Te49/2vKNl++08fY2raZ5Ue\nspQoylWJTU0Hi369/h9u4l/e+tyK6YrabNJq8eKZ54PHzwClpbz5ZOiRPTu3zyuTrua59zw0yniL\nZ5mdr0rnG3UWmZgqsKg/raJ37mOUMz45/3aRZqh22pMHGpUQWbjKxY94tVbUhTkZLM5Mze867EyY\ngZ2ezDM2kaeHmSu7tFUj3Z2z+QI9PeWvoscn89x1+ARGEDz6cj3F1SnzYWSYKyBlaQZ695fvSt0e\njdWJV+eNTeRT01ttVdtcsh4vel87NYBE7WuWsWI0XyiQ3lqYrtxFUXJQYTuOUE+qdtoTA94MPMHd\n329mG4Dz3P2WhqROFrS0jDQeWJJrr0QZZ1JfzlIHS8bdFx6rZJ0Wn6lvvvngcXIGmJXMOXb34Znb\nO3bvLaZvIgwat//0BFvWLysGyjsePFHMaMdiY2yiksfNB2dnCsmMOdk9OdlfIP4exavkkseshrtz\n8NHTnDM8MOs4+4+cnPW+7zt0nAt33cD+XZdmusqu9kp8Mj/N6JlsI67Tjh3fVum1q0lXpX3n6r2e\ndrFS8JnvVPRdTDaeN6ub7nxUW531MYLf4UuA9xNMCf9lYFud0yVdKt5on9ZN98DIKO5OvuD87NQk\nj1syMGufpB2796Zm3jA7qCR/tWemCsVMPvrhJ3/X942MzUpjfHDo9Bwrz0X7HxgZ5SnnDpeMx4mf\nAwQlH/cg3WklguQUGclBqvuPnGTH7r3F40ROjE9xdGySo2OTJaWcQsEZPzvNvgceK6ah4F4xc9ux\ney+nMnZuKNdedN/IGJP5AuNn8wz1l8+mypWM5qr+rDSGKOn46bMsHezlh0dPFauYkoGkMEcUSS75\nEHWZv+vwieJ3Pq3xvN3bQ6CGhnV3f5aZ3QHg7o+ZWdOWx5XuUYCS3DpaNyXu/mOn+cmjpytm0FEp\nYz6iKoX+3p7Uqrm5es3MVaUTD5a3//Sx4vn8+Njp4va0c4iel6W96MDIKOcMDzB+dpq7D58oqSaM\nT0kTHfdASsntwMgopybyJe9BFKDj/QPufehk0A6WeC6J50Xb01b4nJoOXtmd4jQ7+3ddOusY8W6w\n8cw9em+icytX/ebus54b95ufu7VY6oxEC7rF908G/mRJKDpCdC7RMRfCBA7VBpEpM8sRfj/MbDWd\nESxlgWrGjzC6UszaPhMPClmqI6Ljj0/mqzqf6NhpU+IkS3FjE/li+1AygBwYGZ0VHKMr7nij/vhk\naQCJpsSJziGq3ko7hahkEp93LcrY3Wcm+0wGlOSx4iWFeHDP9VhJFVv8fT81Oc0dD56YFYyiEmBv\nzsrOCZf2+UWDa+Np2fZnN7Jt08ricaPz27F7b0m7RqUlsTtVtWfzt8C1wDlm9gHgdcAf1j1VLdab\ns3kPgJPuFf/qVHOFFX/ePQ+d5EzKzMpxaaWsW8P7aa9badqZ07FZC6Iqu+Sxk09PlhYjaYM+oy3x\nudfiJZt4ae30RL64kMevfeqW8rNVh9V68aAYBb9oS1TNNDXtDPbNPPeeh04Wzzk/7dA389rx967c\n+CeY3egdr8aMJi7dd+j4rLa/eNXWVJuO/ahGtb2zPm9mtwEvJfiYX+Pu9zUkZSJd7HSGqWjSVJsl\npWVy5ULNXJdVYxNB54dk9U/8+dFrnc0XylYDxoOTk17aLFdFmezRtO+Bx4q3o8z7wl03zHp/y01w\nWu6ck9V6hcQxoiWrk+9t1ve6k1RdroqtbigiHa7eBe65ZpuOZB19/YOHZ6raNl51XabnxM8pmdFD\n9jRWkuVtyzIn3ULQnpOxiIjQPRlxJ1MQERGRms0ZRMzsO2b238M1Q0RERIqylETuA44CnzKz3Wb2\nnAanSUREOkSWhvW8u38V+KqZrQeuAL7X2GSJiEgnyFIS+Xx0w90fdPddjUtOZWb2CjP7gZndb2ZX\nNex1GnVgEZEFZs4g4u7faUZC5hKOlP974JXAZuBNZra5takSEeluVffOMrN3NyIhGVwM3O/uP3H3\ns8AXgctblBYRESFDm4iZXRO/C2wBPtywFJW3Fngwdv8wwUqLJczsSuBKgA0bNjQnZSIiXSpLw/qo\nu/9mdMfMPt7A9Mybu18NXA2wdevWhTCrgIhI28pSnfWBxP33NiIhGRwB1sfurwu3iYhIi2RpWD8I\nYGarwvutWq/xVuBJZrYpXMPkjcDXWpQWERGhuob1TzUsFRm4ex74beAGggGQ17j7va1Mk4hIt6tm\nFt+WD59w9+uB61udDhHpbsbsmXx76M4V+qopiaiRWqSLrFk2mLo91/LLyUAP2a5st21cUbc09wB9\nOWPxQI6e2DH7e3tYPLiwVizMqpog0iZfHZHuNTzYy8bHDTXk2MnMYMVQ/6zHeoCtG1fW7TWSkpl9\nWuY/PNjL8GAviwd7GejtmbVvMrj0mBUfXzKQY8lAriQdw4nMf7CvfCq3bVrJYF+OC85fxjPXLy9u\nf+b65Wxes7StMslmpaWaIPKehqVCpAnWr1hUvF2vK9OcVc50IvVYc8EI1u0+d2l6CSEyPNjL4oEc\na5cvYtvjV8x6/JJNKzOlZ3iwl3OGB4r3c0bxavuC85dWk/QiMzj0ocs49KHLuGRTaTDqzxlDA70l\nn83QQG8xaBiweCBXXJsd4KJ1y1jU10NPuG+UxiVhOnMGe3Zu58cfvIwff/AyzAwzKyk17N91aUkA\n6suVvjtPPW+4eHvPzu3F1+9N7Ldn53aesLp0svNWBpV2DCJ5M3u3mf1t+PduM3taw1ImC14P2b+A\nRpAhzOeHsWzRzCLbQwP1qXoYGujlpqtemvpYzmbO0ax0ey0uWreMPTu3A0EGnzOKf8lj95ixbsUi\nenpmv9iendt5cixjjF/ZR8+PnrXxcUM8e8Nytm1aWfKeLYll7pXkYq8/PNg7633vIagKumTTSp65\nYQX7d11a3CdnQQa/ec1SNq9ZysWbVvL085cVM/LNa5ZyzVufy0XrgvTt33UpWzeuLAkyydeLnhdZ\nPJAr7jc82Mu2TaXPh9LvzVwG+4LjDfT2BJ9/OxVNGiTTbzic6uSLBN+tW8I/A/65kRMhtsqq2NWX\nNM62TSsz1yP3hrnbQIar/t4yv9yvv+MF2RNXRjLT3LxmKSsX93PJppXFDHNRXw/Dg71s3biy5Byj\nDD9+dZ0MKNHdof7crHP6yv94Xsm2rRtXFv8u2bRyzuA02NfDU85dAsBXf/t59PYYPczOWHNG8Ure\nzEquuDevWVoMZNH9ZEAb6s8Vg2e8yif5Ont2bp9VJRXtF71P0X7x1yy3Lb5985qlXBIGlnKPDw/2\n8vTzl1V8z9Le0nKvDXDdO17AM9Ytoy8sVQ0NBKXCi9Yuoz/8gJYM5FKf26myXo5dAVzg7lPxjWb2\n18C9wIfqnbBW6oKLh7YyPNg757rXm9csZbAvx6OnJvnxsdMlj0WZpzv09fbQl7Pisqo5K11ze9vG\nFdw3Mjrr+QWf3XNkUV8PZ6YKqceJxDOT4tX7qsUsHZy5eo0yzgMjo8VMeMfuvcVt0bn39/bQnzPO\nnJ3mwrXLOH76LD86eipIS3+u5Ko+LR0X7roBCK7eo+PHbXzc4uJV9UBvjkX9OcYn8yXnsWP33tR0\nlss0o/OLnhOd07ZNs9tN0o6RvOqf67WymusY8XMrl45aX2OwL4eFRc/4cft7e8hPT2NmJd/ZoYFc\nRy8DnDWIFIDzgQcS29fQnb3auooRFMvTMtFqpWXGm9csZd+h40x7etfJoN0h/eotfvVtFvxQ448N\nDZQGqB4zLgirRC7cdQPjk3mGBnpxdybzBabCxOUsqPPumZr99Y7OIXnlP9jXw+OWDHD9O17AG68u\nXXInmWnFM+2bDwbjd/tzQX390EDvrP3LHSuekcWvuuPbn/i/rme6kP7hRa9VrfhzduzeOyvozOd4\n1e5Ta9CJPy95jIs/cCNHxyaLj2286rqqjp0WlC44fxkHYhcwaVWq0XeqHr+1ZskaRH4H+JaZ/YiZ\nSRA3AD9HMABQ2tx8vpzG7Mw42l7N4ZYMBFdoYxP5WRnw0EBv8ao4SuOhD11WvDKG4Mf8ldsP885r\n7io+b+vGlbOuguM2r1lazKSToitoCKptBqIrxTA9yaqXyI7de9l36PisTMDMOG/pIGZWEiTSjhHX\n39vD2Xwh6N1j6aWNZKZUTcZ53tJBjpw4UxJg046ZdtxqM/e0QDLUn2P8bPqVdj1KHY2QrGJ71obl\nZfYsL+07EL3n+w6VfieHB3uLFzTAnCXzdpIpiLj7N8zsyQTTsa8NNx8BbnX3zi2HSdWBIDI82MvU\ndIGJlCv1SDJwmdmsTD1exx5lznHJTMljie2x9EyrmqqJePCJXynOdYy0IJN2FZ61WuXAyGhJ8InU\no1fX2uWDrFrSz1d/+/lVpa1WyeP+0se+y2S+syoskr+JZI+tSsoF4vj3I/n9iX/v9uzczqarrium\noVxV6lyGmtT2krmLirsX0LK4HSnq/hhd6ceVqz6CmS9uf19PSZVT8bixq+Z1KxZx+LEzwf4542yF\nb31UzZT2Y4tX78wl+mEnSwnJY5ariqj0vLkkG5gbxcq8V9Udw8pWBzZDb65nVnfYTtFXx5GVaZ9h\n9L2Ll4ohCACnJ6eLv912LpnMu5+jmf26u3+6HomR5ktr1EsWqdevGEpteE1WHUVF8oG+HGeny3/p\nk1dh1VixeKbBOu0HnuXKv5Is6WpE8EgLSvNpY5DOUO5CJrhAmvld1loaaYZ6dJb/E2BBBZHXPXs9\n//tbP2p1MpriaWuWcuuhx0q2RRlpVCJYPpTeT37zmqXccvB4anVYVNqIl35qbXyN/9Be/JRz+Llz\nlvCTo6fKth8krV+xiOOnz2Z6jSy9kbKkUxaWZn+2T1y1mNt/eoKMX/GWyhREzOzucg8B59YvOZJV\nuSuTcg3oUckhrXG80mtAabVVuSCQPM7WjSuLP7xkdVKlH+Sendt50nuvL/aSmvU6ZjxucT8Hq/hx\nnb98EecvXzT3ji3S6Ayq1cGt1a/fKeLvU2+uh57wQizqsp21mrfZspZEzgUuBR5LbDfgprqmqA10\nQvSvRbJRe3iwt9hnvdaishEMBPzm7/48v/bpW1L3GerPUXDPnJk8/fxlTExV7q8xnyqxStotw2u3\n9HSNNq06gvar2sra2vV1YIm7P5D4OwT8R8NSJ1UxghLA0EBvSclgUX9uVmbUn7OKmfCenduLo6Er\n9c9fPNjLYF+u+Bpp+164dhnPWJe9i2R/bw9Lq5hqQqQbRDUD9Zqyp14yBRF3v8Ldv1PmsV+ub5Ja\nz1o8Zr3WV4+PA4gf4+lrg6kd4hn8QKK3zlxzIMVVmvahWZrVO0q604rFwQzGrexVtnXjzLQte3Zu\nL04w2YgS+HxkbRMxd69YgMqyT6do9+qsKMOf1b6RGL2dtUgeVQ3Vq851odfxy8I31J9jeLAxVaa1\niveIzLIAVtaOJ/OVNcx+28zebmYb4hvNrN/MXmJmnwXeUv/kSZpoIrvkDK4Xra08mVxW1WTSyUn1\n2lE7lJxE6iEqgbfThW7WOoxXAL9BMGvvJuAEMAjkgG8Cf+PudzQmic3XrM+nXE+qvnAajKRFfT08\n5dzh8j2kwhHP8ZHf0XoK5cQfq3Z+IBFpjE666Mk67ckE8DHgY2bWB6wCzrj7iUYmbqFLq0YaHgwm\nAywUjHxs0ry0onWWeXbm0wjXqi9yJ/2ARLpd1TlMOB38SAPSIpQ2mkXBJS2ApM0CG38sbR4qCBYZ\nimYnbRYFBZGFq736irWJZvQOGOrPzQoMtfQD2bNzO098z3XF23M5d+kgPyszersvZ2UH+VV6fRFp\nvPhvLZpPq9YJVOtJQaRBKg0I6oHUBYayrvKXVaUBeWldZLesX976b6SIZFavdX7mlYZqdjazzSnb\nXlS31HSJZLDoyxl9FQb/ZZmWvB4DkHrMUtfkFhEpp9oalGvM7N0WWGRm/wf4YCMSttDFSwKDfbnU\nqboXD+R45vrlc3ZRLdfNttyAPA3UE+l88XXo0zSr6321QeQSYD3BfFm3Ag8Bz6t3opLMbJeZHTGz\nO8O/VzX6NRuh2mv8HrNZq9FlpbERIrXbs3N7249/ahfV1oFMAWeARQTjRA6Gi1U1w0fd/a+a8UKt\nHHeftgqaiMhcWjUxY7WXubcSBJFtwAuAN5nZv9Q9VQtUX29Pce4blRJEZD6ijjN9OStOG98K1b7q\nFe6+L7zJKBAnAAAMTElEQVQ9AlxuZv+tzmkq5+1m9qvAPuD33D05LT0AZnYlcCXAhg0b0naZ0+I6\nrU2cvDI4Z3iAk2emaj6eAo+IJA325VJXGm2WaoPIqxrVHmFmNwLnpTz0XuDjwJ8SdED9U+AjBNOw\nzOLuVwNXA2zdurVlFVPRqn7xQLJiqG9WEIkGBrbqCyAiC1OzLjqrDSKnY7cHgVcD99UjIe7+C1n2\nM7NPEKxv0nGG+ls/LEelGRGpp6pyNXf/SPy+mf0VcENdU5TCzNa4ezTVymuBexr9mvWQZW6rdqIA\nIyLVmu+l8RCwrh4JmcNfmNkWguqsQ8DOJrzmvEVdBG8+eLzqHgzlZuott6+ISCtUFUTMbD8zE2Pk\ngNXA++udqCR3b1bjPdCYxVzmOqR6bIlIteIXm5vXLGXfoeNMe+k6Q41W7QXyq4H/Ev69HDjf3f+u\n7qlaANIGKmkAk4jUQ9osFdESus1WbZvIA41KSDtp5Cq/Km2IyEKSdY31MWaqsSx52911eR1Tr5Kk\nAo6ItLusJZGnd0sppB40Ea6ItFIzq7WyvtK1wLMAzOzL7v5LjUtS69WjYT1eiogWjcqyr4hIraLG\n9WbKGkTiueoTGpGQhaRVc9iISHdopwvPrL2zvMxtSVBNloi0UqUVTRsh6yXzM8xslCCPXBTehi5v\nWE9OsDgcrliY/ABVMhGRRml1qSRT7ubu9ZnWdoEZGujtmClNRKQ6rc6ca1HNTBf1UtuyeV0uZxTX\nBRER6WYKIiIiUjMFERERqZlafOukUq8sVXuJyEKlIJKilm66lUapd2IDnYhIFqrOEhGRmimIZBD1\nxoobGuhVCUNEup6CyDwtGdAQGhHpXgoiKZ6+dlnmfaPJGps91YCISDtQw3qKizetZPFAjtOT0yWN\n7M1cclJEpBbNrmZXSaSMHjN6gKFEddXQQG/JXFib1yxVcBGRrqWSSAVmQTCB7JMobl6zVA3uItI1\nVBIREZGaKYhkoEZzEZF0CiIiIlIztYlUYf+uSwGaPl+/iEi7aqsgYmavB3YBTwMudvd9scfeA1wB\nTAPvcPcbGpmWzWuWcmBkNLUaq1zDuRrURaTbtFUQAe4BfhHYHd9oZpuBNwIXAOcDN5rZk919uvlJ\nFBGRSFsFEXe/D2ZGgcdcDnzR3SeBg2Z2P3Ax0JR6JZUwRETSdUrD+lrgwdj9w+G2WczsSjPbZ2b7\njh071pTEiYh0q6aXRMzsRuC8lIfe6+5fne/x3f1q4GqArVu3+nyPJyIi5TU9iLj7L9TwtCPA+tj9\ndeE2ERFpoU6pzvoa8EYzGzCzTcCTgFtanCYRka7XVkHEzF5rZoeB7cB1ZnYDgLvfC1wDHAC+Abyt\nnXpmaUS7iHSrduuddS1wbZnHPgB8oLkpykaTLopIt2qrkoiIiHQWBREREalZW1VndSJVY4lIN1NJ\nREREaqYgIiIiNVMQERGRmimIiIhIzRRERESkZgoiIiJSMwURERGpmYKIiIjUTEFERERqpiAiIiI1\nUxAREZGaKYiIiEjNFEQq0DohIiKVKYiIiEjNNBV8GSqBiIjMTSURERGpmYKIiIjUTEFERERqpiAi\nIiI1UxAREZGaKYiIiEjNFERERKRmCiIiIlIzBREREamZuXur09AwZnYMeCDloVXAo01OTjvR+ev8\ndf7dK8v5P97dV2c52IIOIuWY2T5339rqdLSKzl/nr/PX+dfreKrOEhGRmimIiIhIzbo1iFzd6gS0\nmM6/u+n8u1tdz78r20RERKQ+urUkIiIidbAggoiZDZrZLWZ2l5nda2Z/Em7fZWZHzOzO8O9Vsee8\nx8zuN7MfmNmlse3PNrP94WN/a2bWinOqhZnlzOwOM/t6eH+lmf2bmf0o/L8itm83nH/XfP5mdihM\n951mti/c1jWff5nz76bPf7mZfcnMvm9m95nZ9qZ9/u7e8X+AAUvC233AzcBzgF3A76fsvxm4CxgA\nNgE/BnLhY7eEzzXg/wGvbPX5VfE+vBP4AvD18P5fAFeFt68CPtxl5981nz9wCFiV2NY1n3+Z8++m\nz/+zwG+Gt/uB5c36/BdEScQDp8K7feFfpcaey4Evuvukux8E7gcuNrM1wFJ3/54H7+jngNc0Mu31\nYmbrgMuAT8Y2X07w5SL8/5rY9m44/3IW3PmX0TWff5UW1Pmb2TLghcA/Arj7WXc/QZM+/wURRKBY\nlXEncBT4N3e/OXzo7WZ2t5l9KlacWws8GHv64XDb2vB2cnsn+BvgD4BCbNu57j4S3n4YODe83S3n\nD93z+Ttwo5ndZmZXhtu66fNPO3/ojs9/E3AM+HRYnftJM1tMkz7/BRNE3H3a3bcA6wii6tOBjwNP\nALYAI8BHWpjEhjGzVwNH3f22cvuEVxYLsitehfPvis8/9Pzw+/9K4G1m9sL4gwv58w+lnX+3fP69\nwLOAj7v7M4HTBNVXRY38/BdMEImExbhvA69w90fC4FIAPgFcHO52BFgfe9q6cNuR8HZye7t7HvBf\nzewQ8EXgJWb2f4FHwiIq4f+j4f5dcf5d9Pnj7kfC/0eBawnOtVs+/9Tz76LP/zBwOFb78iWCoNKU\nz39BBBEzW21my8Pbi4CXAd+P3sDQa4F7wttfA95oZgNmtgl4EnBLWPQbNbPnhL0SfhX4atNOpEbu\n/h53X+fuG4E3Av/u7r9CcJ5vCXd7CzPn0hXn3y2fv5ktNrPh6DbwcoJz7YrPv9z5d8vn7+4PAw+a\n2VPCTS8FDtCsz7/VvQrq8QdcBNwB3E3wRfnjcPs/AfvD7V8D1sSe816CXgk/INYDAdgaHuPHwN8R\nDsjslD/gRcz0Tnoc8C3gR8CNwMouO/+u+PwJqmzuCv/uBd7bTZ9/hfPvis8/TPcWYF94rv8KrGjW\n568R6yIiUrMFUZ0lIiKtoSAiIiI1UxAREZGaKYiIiEjNFERERKRmCiKyoJnZR83sd2L3bzCzT8bu\nf8TM3lnn1zw1915VH3NLYhbaXWb2+xmeZ2b272a2NLbtNWbmZvbU2LbVZvaNeqdbFj4FEVnovgs8\nF8DMeoBVwAWxx58L3NSCdFVrC/CqOfea7VXAXe4+Gtv2JuA74X8A3P0YMGJmz5tXKqXrKIjIQncT\nsD28fQHBQKoxM1thZgPA04DbzWyJmX3LzG4P11O4HMDMPmRmb4sOFi8BmNm7zOzWcIK/P0l78bR9\nzGyjBWs+fMKC9W++Gc60gJltC/e908z+0szuMbN+4P3AjnD7jvDwm83sP8zsJ2b2jjLn/2Zio47N\nbAnwfOAKgtH9cf8a7i+SmYKILGju/hCQN7MNBKWOvQTrzWwnGJ27393PAhPAa939WcCLgY+EUz/s\nAd4QO+QbgD1m9nKC6SIuJiglPDs56eEc+zwJ+Ht3vwA4AfxSuP3TwE4PJhOcDs/hLPDHwB533+Lu\ne8J9nwpcGh7/fWbWl/IWPA+IT0x5OfANd/8h8DMze3bssX3AC8q8lSKpFESkG9xEEECiILI3dv+7\n4T4G/LmZ3U0wRcRagqm07wDOMbPzzewZwGPu/iDB/EwvJ5hu53aCDP1JidettM9Bd78zvH0bsDGc\n/23Y3feG278wx3ld58GaEI8STK53bso+K919LHb/TQSTVBL+f1PssaPA+XO8pkiJ3lYnQKQJonaR\nCwmqsx4Efg8YJbjyh6AaZzXwbHefCmcEHgwf+xfgdcB5BCUTCILOB919d4XXTd3HzDYCk7FN08Ci\nGs4reYy033PezHrcvWBmK4GXABeamQM5wM3sXR7MfzQInKkhHdLFVBKRbnAT8GrguAdTgx8nWD50\nOzON6ssI1iSZMrMXA4+PPX8PQfvB6wgCCsANwG+EbQyY2VozOyfxuln2KfJgGYMxM7sk3BRvsxgD\nhqs56dAPCCYoJEz/P7n74919o7uvBw4yU4X1ZGZmuhXJREFEusF+gl5Z30tsOxlWBQF8HthqZvsJ\npsD+frSju99LkIEf8XClOHf/JkF1097wOV8ikcln2SfFFcAnLFilczFwMtz+bYKG9HjDehbXEcxs\nDEHV1bWJx7/MTJXWi8P9RTLTLL4ibcTMlrj7qfD2VQTTl//PeRxvDfA5d39Zhn3/E7jc3R+r9fWk\n+6hNRKS9XGZm7yH4bT4A/Np8DubuI2FX4qWJsSIlzGw18NcKIFItlURERKRmahMREZGaKYiIiEjN\nFERERKRmCiIiIlIzBREREamZgoiIiNTs/wPUduX3sNGuDAAAAABJRU5ErkJggg==\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAb8AAAElCAYAAAB07uxXAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAAMTQAADE0B0s6tTgAAIABJREFUeJzt3XmcHGd97/vPr2eTRpJleWTZAtsjGVl5mYCPxX2AsMrG\nKMQhIeRwwpKYsJ1zISHJAQXCopxz8oL4BhIYuEACJAdiIDjHAQdCwA7oYltgMDEPYOMEE3mVbcDW\nYtmWZiTN0s/9o6paNT29d/U29X2/XvOa6arqqqdrqutXz24hBERERPKk0OsEiIiIdJuCn4iI5I6C\nn4iI5I6Cn4iI5I6Cn4iI5I6Cn4iI5I6Cn4iI5I6Cn4iI5I6Cn4iI5I6Cn4iI5M5wrxPQK29961vD\nxo0be50MERFp05VXXvmP3vuXNPOe3Aa/jRs3snPnzl4nQ0RE2nTllVfua/Y9KvYUEZHcUfATEZHc\nGZhiT+fch4AXAZPANu/9LfHyG+Jlj8abfsp7/4GeJFJERAbCwAQ/4PPAnwM3Vlj3Zu/9F7ucHhER\nGVADE/y8998AcM71OikiIjLglkud3587525zzl3lnDu314kREZH+NjA5vxpe6b2/3zlnwBuBLwNP\nLN/IObcTKPVt2LZtW/dSKCIifWXgc37e+/vj38F7/xHgXOfcRIXtprz3ZyU/559/ftfTKiIi/WGg\ng59zbtg5d0bq9UuAh7z3h3qYLBER6XMDU+zpnPs48ELgTOCrzrkjwH8CvuKcGwOKwEGi7hBdsWNq\nDwC7d27v1iFFRCQDAxP8vPevr7JKzT9FRKQpA13sKSIi0goFPxERyR0FPxERyR0FPxERyR0FPxER\nyR0FPxERyR0FPxERyR0FPxERyR0FPxERyR0Fv4zsmNpTGu5MRET6m4KfiIjkzsCM7dmP9h2a6XUS\nRESkBcr5iYhI7ij4ZWjfoRnV+4mIDAAFPxERyR0FPxERyR0FPxERyR0FPxERyR0FPxERyR0FPxER\nyR0Fv4zsOzTD3EKx5jYaAk1EpD8o+ImISO4o+ImISO4o+GUooPE+RUQGgQa27gLV84mI9Bfl/ERE\nJHcU/DpArTpFRPqbij0zlu7uoAAoItKflPPLwI6pPTX7+O07NKOGMCIifUTBL2Nq8Ski0v8GptjT\nOfch4EXAJLDNe39LvHwD8GngCcAJ4He999/oVrrmFooKdiIiA2aQcn6fB54N7Ctb/h7gO97784DX\nAFc650a6nTgRERkcAxP8vPff8N4/UGHVS4GPxdt8F/gpsL1b6QpQd0zPhOr+RET6w8AUe1binJsA\nRrz3D6YW3wucU2HbncDO5PW2bdvaPn4xBCAKgCIiMjgGOvg1w3s/BUwlr6emptqOWfNFhT0R6Z6k\n+9TunV0r3Fq2BqbYsxLv/SFg3jl3ZmrxJuC+3qRIREQGwUAHv9jngDcAOOeeCjwe6Gnvcs3rJyLS\n3wYm+DnnPu6cewA4C/iqc+7OeNXbgGc65+4ArgAu897P9SiZIiIyAAamzs97//oqyx8CfrHLyRER\nkQE2MMFvOSgvDlXltYjkWS/vgQNT7CkiIpIVBT8REckdBb8OqTeaS1ajvajlqIhI81Tn10XqEi8i\n0h+U8+uAAMymGrfMLRQXNXbZd2im4fFARUQke8r5ddi+QzMEwHqdEBGRPtPLgf4V/DpIuTsRkf6k\nYs8WhdBcDV6trdVoRUSku1rO+ZnZGuA5RMONHQNuDSH8MKuE9bvrfry/10kQEZEWNR38zGwSeBdw\nKXAb8CCwAniHmRWAPw8hfDLTVPahg0dPtPze8uJQTXArItJdreT8PgO8D3hdCGE+vcLMNgGvN7Pf\nCyF8pP3k9S9TExYRkYHVdPALITy3xrp7gXe0kyAREZFOa7jBi5mtMLPRsmUbs0/SgGgg4xdovGP7\n3EJRjV5ERLqkoeBnZm8GrgG+bGYfNbOV8arPdixlIiIiHdJosedLQgjPBjCzHcA/m9nvdC5ZIiKy\n3KSnMNoxtYfZhWLPWk80GvyGzGw4hDAfQthtZrcDfwts7WDa+loW/7C5hWLbLT3nFoocmp7l4elZ\nTls1Wv8NIiJd1o9VOo3W+b0FWJ+8CCE8ALwQ+ONOJEoad+DICY4cn+dDX7+j10kRERkYDeX8Qgjf\nqrBsFrgi6wQNCrPW837pRjAhhLb2VYx3dmJeQ6mJiDSqnRFenkvU329LvB8DQgjhlIzSlgtzxcDo\n0MngV148sHvn9m4nSURk2WtnYOu/AXYBNwML2SRncHSykjapB5ycGK+4Pl1pLCIizWsn+D0WQvh8\nZimRRbJoDCMi0o92TO3p+f2tnVkdrjazV5Z3fJfsNTbrg+aJF5HB0A8TercT/G4H/go4ZmYLZlY0\ns9wUf7bRRqWiANy5/2jD2+87NNOXzYdFRCrZd2im9NPrwAftFXt+APg1wJPHOr8Mg1+lCyEAsy0M\neZZlfaDqFkUka3MLRQKdbTfRiHaC3/4QwnWZpURKub+Roe7NMawAJyLdkgQ+6H1FTTt32S+Z2e+Z\n2QYzOyX5ySxlkhnNFC8islg7Ob8/jX9/CEq52AAMtZuoQZDlfH61noD2HZqp2uWhXyj3KCKDpuXg\nF0LoXtlczqTrAPuhYlhEpB0hBELodUHnYu2M8PKrwDdDCI/Er9cBzwwhfCWrxDXKOXcvcAI4Fi/6\nM+/9Vd1Ox3JVnrNTTk9EGrVjag93HZjueR1fuXaKPd8dQrgw9foR4N1A14Nf7GXe+1u6dbCsuzrU\nk+7a0MvOoUnn1H4vihVZjnrdMbwRlR6OawW+ANz/8Axnn9bde0pmRZchytPmor6vmwK1L/inTJ4K\nwN/ffD9bd13bpVRlT41yRJafrbuubaj/8jW3/awLqVmsneB3xMyembwws2cBR9pPUss+45y7zTn3\nCefc6T1MR9vqNYBppx5w665rFwXJfYdmuHP/0UwDT/kxWqWAKCKd0k6x5x8BXzCzH8evzwN+vf0k\nteS53vv7nHMjRK1QPwX8cnoD59xOYGfyetu2bd1NYRvmFoqMDBXqBr5kXVJE2m6d3EIx8OixOU5d\nOUKhUL2cN8mZKlCJSCu6XY0E7bX2vMnMzgeeES/6dtL4pdu89/fFv+eccx8E9lbYZgqYSl5PTU21\nVf/azhx8tdRLVLK+GLec+v6+6qe8VjBKr6tWtHpoepZHj82xUAycvmaMHVN7mhqCrVGqRxRpzKxa\nf2em6eBnZn8JfBG4LoRwGLgm81Q1wTm3Chjx3idR4BXAD3qYpI5Ij4wAMF8MSwJREsTSM0KUB5Ra\nOcekqHLv5ZdGx4i3nS+GgahoF5GTBqlVdpb9phvVSs7vOuBVwMfN7NvAF4BrQwi9ujueAVztnBsi\n6mh/N/DbPUpLR1QbB6/d8fH2HZqp+CTZbPFlv/TfGaQvu8hyNggD7zcd/EIIVxNNZzQMXAy8GHiv\nmf2IKEf4pRDCwWyTWZ33/m5gcCrwWtRoeKkUzO4+ME1I7aFSMefsQhGDUt0iwMhQY6F1vhgy7cPT\n718aERl87dT5zQO74x/M7GlEDV6uB56cSeqkrkaCzkKDObNGA1ggagxT/j4VjYpIopmW6QPV4CXN\nzNYCMyGEdwDvyGKf/a5fivqqabU7RPK+9MwSx+YWKBA18kk+9U8eOdZ2Di39/tmFIncdOMr0ifnS\nsmIIGt5NRDqineHN/gV4OTAP3Bov+3QI4X9mlDbpgUohfaEYWAAstfbEfIU5CEOIAmRorRi0GOBT\nN91bev3go8eZnl3g9p89xvkbNWGISL+oVL++dde1pW5Zaf2aTWink/sZcdeGXwb+id728+u6P7vm\n9l4noabA0rq98o7n7TabvnP/0UUtTufiotC5YmC+GHje+26o+L7yzuvpXPTx2ZPzIk/Hf7/2iu+2\nlc4sqeO9SG0hBGYXisyWtVDvN+0Ue47Ev58L/EsIYc7M5mu9QXqrmSLE2YUicwv1t6v0vkrS45LO\nLRTZsmF1ad39h49VfE8t6SfP5O+5hSLHW0l0m9TKVOSkuWLzIa9T/aZraSfn929x0eevANeZmXoo\nD4B2nsQqvbfW/u4+ON1QLildhNpO+u57eIYHHzvBvQen29iLiORB08HPzP7SzHYArwM+Blwc9/Fb\nR04auwySdG6v10UQ7YxLWq24MRkdBqI6Q4CjJ1QA0QoV6UqetNXJHfg2MGRmD4UQfgL8JMvESfuq\nBbxG6vsaHWqtlmYHzT5yfJ4HDh9jYvVoadmBIydYPVb7Us26m0W1OQxbea+I1NaDng7N5/xCCFeH\nEC4DthINIP084Idm9iUze62Zrc86kTK4yhvdJA1xEuVB6ws/+AnH5hZ4oMF6wGSUmm51iUjGVG00\nl6TclPTKnfuPcteBzo3FO1+s0OI786N1Tst1fiGE+RDC7hDCG0MIW4hmUziPqJO7SEl6rNG0ew9O\nN9zidN+hmSX7qFaM+jt/972OBJxjswvcdWCaR4/NLVoeQuD43EJf9/1cLkF4uXyObgicrApoVfn5\nTgLfQjFwz8EZ/umWk4V97bQeH9hO7gAhhJuBm1G9n5QJLP1i7Ds0U7FVWHlggWj4tJFC9Dv5It5R\nYVDvRqRnkGikWDLdSjV50n302BxrV46Uttl/5ASPHZ/nG3ccZPvW6lNJVioOHdQi0kbT3evP1+vj\nd8oDh2c4a13v2hgmJSB7/uMAv3bh4zl09ETP0tKqdjq5n1Nh8SMhhMfaSI/kRLNPiXPF0NV6gfJZ\nMcpn1UjsmNrDY8ejBjZ/+A+38Nix+YodfdP77EcHj57gJ48cY32qrlX61/xCZ0sZajUuS38Xdt/+\nEDum9pRmgBkk7eT8vgecBiSP6iPAUTN7APitEMIt7SZOJK3Rr/vPHj3OQpxLrPfEXz6NU9rcQpE7\n9x9lZKiw5NhJEWd5/6RkdJtiCDXnKaxXdNdMDrVejrKR+RI/ceM9zMwucP/Dzfe5bEczOcgQAo8d\nn2fV2FDHjjMoelXAXukhcN+hmbaL/HvR4KWd4PcJ4MdEjV4MuAx4EvAt4CPAs9tOnUiZRibTnY+L\nU9PTqqSDQKU6yPKbYzEOYtW+lHcemGbV6BCPO3XlyYXh5E0pScNsHECraSQ3mE73yFBhURCrNm9j\nuXo3pz6uriyZnl1g/5ETrDhWu6nCcgt0/aT8Mpk+Mc9wodBSx/a0XnRybyf4vSCE8Pb47wB82sy+\nH0L4IzP70wzSJrJEM1+xdGOYJIAkxa3pdUkwnFsosvntX2HLhtWl4FVJ0il/enbxaDKHZ+YWzaCR\nBKbyPe2Y2sMd+4+WppBKL4elN+16/SPTwTzd73FyYpwdU3u45+A088VQsT410ey9pxgaK4aeWyhy\n/8PHeP77byjd4CoFpUo53fLzkcwkcrzCuLKVPP/9N3DXgWk2rl3BqjpdZcrTUi2d/SL9MFMvvbVK\nQCqNlJRse+/BaeaKgeGCLbquymXR0voj193Bq565qe39NKOd4DdmZueFEO4AMLPzgBXxuu6PMSVS\nRbUv7Y6pPRWD4ZKuGTWyRelta00dtXXXtcwuFBkpnAwZ6YZACxVyq3NlucZQtmxkqLDkxpMOlMl2\nSaqOHF8c/NI3u2afu+86ML1oH4ndO7cvKkp+4PAxFkLg+FyR/UdabxSxUAwcnpldlPZ6wen4fFRE\n99NHjzNalmNOp72RwFBLM/sZhMBaatEZX8/JtVntezAAhQYVtRP83g7cZGa3xq8vAP6rma0Grmo7\nZX1uUP/heVY+2k2jw6DVKtKp1XCn0s1irhgWzYWYuPHOk/M/l+cY04EpKYqt1IK2UnrS7z02V2Tr\nrmvZe/mlS+oB//7m+0r737rr2qp1jZXqKqsVve6Y2lPKQVd7MJhbKHL0+Dynjo9UXJ/Yf+Q4c000\n8ig/9/PF2n1B2wlK6Vx3eh+1zlW1Yza67AUf+AbzxVAaIzd5aKqU/nrryiUDU5deU7119iBrKfiZ\n2RDwLOB84Bfixd8JIRyI//6zDNIm0pZAlPtJB4y0St/lakGlFdVuFpVuwq/65M2lv0eHCqWm5Ema\n6pkvFnn++29Ysrzee+/cf5Stu66t2GEZlhajVlOtL2fiZ48eL/0P0jfie+P3jA4XluxjvljEiIrc\npk9UL0wqDw53HThKMcBZ607WxxYDPPRY/ZxnUiQ9UjA2rV9Vd/ss1WuYlB60Pd36Oen2c0c8mlJ5\nkKt3Pc8tFNkxtadUUrBhzVjDaR7keNhS8AshLJjZxSGEtwH/nHGaBkIvWidJ80LZ77SFJgNMO9I3\noJ89erzhbSuplNZiaL4rRbrlXvomlgShdOCbWyiWbrKjFbpxJEWy5fuolu7yXNFP43OS/uz3HIze\nf96G1Us+8z3xoOmVcjPJZykfJShpgQsnA2W6mHnfoZnSQ0elOt9KxZfpeuRqkvP2/PffQAiBuWJY\ndG6TfddrzFV+nErXQfrzVFpefr6KFeberFXf3TmD1eDlGjPbBXwSKJUfqZ+fSG2durk0UiyVPOXf\ne3C6asBPcr/l9Y2J9E14dr54sk4IuOT9N5TWt5qDTiZFTZQPaADROUwCVaNBP2modOf+o5z3zmso\nFIzZOEgvFMOSh6GkodDz3ncDQwUrdXtJjlne7D/JMZb2EU/unLjzwMli9nTQTAfCwMkcXnIehguG\nmfHij3xryWeqdG4qqVTUHuX4o+Xp6+GRmaUNo7IqDekn7QS/ZMb2d7O4KqL5TjgD6MCR2fobifSZ\nQOM3zEZC9L6HFweewxVunOWKIVCo0by00RvtXQem2fz2r9TsklJNYPFUWpXqJJOAce+haYYLS/t6\nVpLk6k7MLXDf4WNsXLui8nZlnzEdSO8/fIwdU3tKy6KHmsDdDdRRJ8G8vOh0IQTuiIu40wM3pNOd\nWJoXXJ5aDn4hhHbmAhSRPpHlU/3D0/UfCu86MM15G1ZnMuJNebH2JRXqPdMqFS020oox2SbERae1\nzln64eLBKkXc5TnGWvto1myqiLpcvbpZGOx6vGa0NbanmW0Efi6EcIOZDQOFEIKyRCJSUzs392qS\nXGAtJ+s4T25Zr7i4GE5uP1cMDQ20UH68frMcizGb1XLuzcz+C/Ad4Ip40c8DX8wgTSIiTWsm0LST\nu+nXgNaI8oZJedZO0eU7gKcAhwFCCLcCk1kkSkREOqMvg3cPms+3E/wWQgiHypapyFNERJoyEDO5\npxwxszOIHyTM7BLg4UxSJSIi0kHtNHh5G3AtcK6Z3QhsBl6YSapEREQ6qJ2uDt7MLgaeSZRr/XYI\n4ZHMUiYiItIhbXV1CCE8SpT7ExERGRhtBb9+4Zw7j2hS3fXAo8Crvff/3ttUiYhIv1ouo7R8HPhr\n7/1W4L2c7HvYMbXmbhMRkf428MHPObcBcMDfxYuuBs52zm3pXapERKSfNVTsaWYXhBB+2OnEtOhs\n4Gfe+3kA731wzt0HnAPcmWzknNsJ7Exeb9u2rdvpFBGRPtFond91ZnYX4IF/Aq4LIcx3LlnZ895P\nAVPJ66mpKZVbiojkVKPFnreFEJ5OVJf2XGCPmf0fM3tFx1LWuPuBjc65YQDnnBHl+u7raapERKRv\nNVXnF0L4bgjhj0MIzyIa2/OMziSrcd77/cD3gcviRS8BHvDe31n9XSIikmeNFnu+p3xBCOEe4IPZ\nJqdlrweucM69E3gMeE2P0yMiIn2soeAXQvhqpeVm9sQQwo+yTVLzvPf/ATyj1+kQEelHIwWrO29h\n3rTb1aFfcn4isgwNFwwDRocKnLdhdWb7rTWLQC9mGGjH6FChbprPPm28K2kZJA0FPzN7zMy+Zma7\n499fM7PdgPoLSO51+mbZq5txL4PAkJ08+sjQydtUFmkaHSowUiFgGLB5/aqK66o5d/2qRWlthVX5\nuxlbNqymEL+5PD0rR4b4599/dot7Xr4azfntBV4aQtgRQvjF+GcHcEsH0ybSMKMzN+vRoYEfB6Jl\nI0MFzl2/Cmjs3I4UrO1AkDh1fKT09+TEOJMTUc5ly4bV7HnrRTXfm05BoUpyJifGFwVViD7v9W+5\niL2XX8o976k8Qc05p42zemyYkYIxOlRgqGAMFYwtp69adPzRoULpJ7k2K12j521YzT3veWFp2y0b\nVi+65s5dv4rhah8i9VkgCnob165g8/rxRfs485QxVo0NVz0XedXoN3sHcKR8YRwARXqine/yaamb\na7u2ZFgcV260Sq4ny6Cc3KzLX09OjDMU3+RH4ptzpeOPDcc3eYsCQSXporny49VLW2L3zu3s3rmd\nyYlVjMTHqbSvQp0APDkxHu9nvGZgSfY7OlRg8rRxzl63krHhAhvXrmDT+lWloANgZTnVvZdfyt7L\nLy0F2S1xkEsCXaU0pdM1OlRgy+mrGCoYjz915ZLtk88/OlRg987tpTSsHhvm//vDixalbTg+XvrB\nZLhgmRYjt6tvJ7MNIRwOISwkr83sjzqXJJHmjcQ36EasHhvm+rdcnOnxaz3dt2Pv5ZeWAk86yE5O\njJeOVbDqxzWoe5OrlANKbsTVTE6Ml26m6Zt9LUmuJtl/Iik6TN+cX/vszaW/k6C36HNZVBeY7Gvj\n2hWcecpYlPuM6wkNOHVl9JCTFGk+4fRVpX3t3rmds9adDCzpNEF07ksBcLjAipGhJZ8pCVZwMsCn\n97N753b2Xn7povSn/3f1PmNy7E0T44tyl8nxkmOl09GIzetX1fz/ltLQ8B4HT6uPj7+UaSpEmmSw\nJBg0+uXfuHYFa8dHGK5QTFf+ZU+ewmsFtt07t5eCb/KT3q5aUWA6J2Rly9LqBZbhwsnj1mv8kBTX\nrVlRvaF3tfNYvnzz+nE2rBljw5qxqsc685QVnLFmrBQA0jmckYJF/4P4J8mErR4bZmUcaAoNFPnt\n3rmd1WPDrFkxUsqRJefjFU8/p7TtcMGW5ApveOvFbFgzxuRptYN9o0ZSObFqdu/czpYNq9myYXXF\nbSsFspE4Z51W7wGl3Kb1q0r//0Zt2bA6kzrJeh473v0Bw1oNfsv5gUC6pNaXcOPaFTXfW94IolT0\nQ/WLszwwFMwaqgfZe/mldYs2k5t68tNILrQ8SCY5mUaV53bTDwDJeSi/GSc30A1rxhiucCMcMluS\nC5mcGC8Fr7PWrSz9b8yMtStHFhV1JrmaZP2aFcOcsrJyEbNZFIySm72ZxQFzjN98+jmcunKk6nUw\nOTFeNXikveDnzwRqF4WuXTnC6HBzt8L0OUr+biT326xKOUKAcyo8oJSnKbkG0ss2rV+15H1AKedd\n6fuQvsaauT6bkVFVcVNanc9PHUakY+o1Qy8vNkskX/IdU3u4Y/9RIHran4/7N01OjLPv0Exp+8mJ\nceYWitwbL1s3PsL61WOl995bpdFDUt8yVwylv8tNToyX9rNp/Th3H5gmAGvGhjlyYn5RepIn+B1T\newC45+B0Kc3VJNsnnye9j+QGlc4ZVKoX2xzfCJM0pM9N+jhpSY4sfa7Lt9+661pmF4pV050o/x+m\nX68YGeL0KjnKSumq5oKzTmWkYEtyTY3KOpglGskd1nLNf38OY8NLi2HTqj2wpa+LiVWjDA8Zh6fn\nAAgBivF0bUngTL5PQ2ZMToxz5/6jmQeA9atHM95jfa0GP+X8pKbkAqn2JalX9FJpfRL40jekrbuu\nrbmfjWtXcP/hYzW3SaxfHd1sRwrG48oaGZQHmyiNVrOoNTkH6VzHytEhpmfnS40Y0jei5Hf0mcKS\nc7B753Y2vf0ri17D0gBUKU3JsvIAl77Jlu+nVemg3i3lwSL9WZLcThbFmr2SpD39/8/CaauioJME\nv03rV7Hv0AxzC8VFubzRsgdO4+R3O/13q4YL3W9V3Wrw+91MUyG5UZ5z23dohhDCotEnRoYKS4qh\nyr98iWo32OGCcfa6lXz4N5/Cr3z4RoBFuatSeio8xplZ1WKwaserdGPduuta5spyQEb0RV8xMlTz\nZlzecCKxamyore4EyYNDVoGukkrnuZH3QGfTVe/YedDKZ03/P5Oc/dxCsfRwNzJUqJrT72ctBb8Q\nwu1mdi7R7AkA94UQ7s4uWTLokqfG5Etxyophjs0uMF8MS4r50qrd9Kup9mUumJWaeNfafrhQWFQ0\n2sixGr1Bp1vibU6e2NssM3nc2qXN3tOfqds38mrHayQd1Rp7ZGG5BzTLuPCtm7n0ftF08DOz84FP\nEU0im0wbdI6Z3Q+8JoTw7xmmTwbU3ssvLRVJGnDGKSsqBrzkS5fUj6WLWobMWAhh0XZZSgezpDiw\nlVxLI5Kn46w6gber1cDTzaCiQNg95Q921erVIfpul9c3J0Wl6UfI0T7PEbaS87sCeG8I4er0QjP7\nL8DfAk/LIF3SRZXK7BvJDVUr62+lA3alfZ22apQDR080va9OBbB2PO7UFRw9Mc+Nb3seL/jgN2pu\nm84xZkUBQCopvy7ydJ20EvxOLQ98ACGEz5vZ5RmkSbpsZKiw5Knt7/7r03n5X39n0XZDZowOG8fm\nKj/NJUEvqVdKWoY1K/kCXvL+GxYFv375YjaajvR2I0MF1o2P1u231sz+Jb/6oQAh3Vhr665rl9xH\n0i2e+1Erwe+gmb0S+GwIoQhgZgXglcChLBMn7UkXG9ZSHqSMqMlzuYLBWesqX9AjhcotH2v1Cyov\naimv76s3TFWWKrW67BQFNxk09XKIyfe2lYdd6E33gVaC36uAjwMfNrOfxcs2Es2m/uqM0iUZmFg9\nyv4jUc6pnSLK5L3lHWTrtfKq1D2g1o2/0ugY7X4pGoj9A0WBU/pZck/og4xpXU0HvxDCncAlZnY6\nUaMXgPtDCAcyTZk0rF6fuvTQWdW22bJhNfsOzVQNZukOr8n+JieiztuN5C5rqVdH18iQUZX2CXB4\nehaIOpfX21ZEWrO4j2oLehAtW+5ZGEI4EEL4fvyjwNdj1YoXk351jQz8nAxNNTJUINTptpoEpGRo\nq2ojaDQ74G75e9sdTmndqlGesH4VZ5xSfbQQkUHTrzmrQeoy0Won94rMbG8IYWuW+5T6kmGMyuvi\nxoYXj/tYaZt0XVcyNFY0Sn7Un2zlSIHjZQ1c0s2gW23U0k2NNDLpNOUuJS+aHaO2V1rp53dBjdVr\n2kiLtKnPDuGgAAARV0lEQVS8+HPFyNCS6WnSwyOlB70tt3n9Ks5et5LRocKS4cGaHU1eN36R7uvF\n9y4ZAWYQtJLzuwW4l8o574m2UiNNS3eaTo+qUiuwlW9fTTJ/Wb2ijGR0/Xb61ilAijSu1YG65aRW\n8qb7gGeHEDaX/wAPZZw+qaP8O5DMP1ctsJ1z2kqGrPLgSO3Uz3VKJ6aJEZHOSc/Z2M8hupXg9yXg\n3Crrsh1yXKrOzt2qseEhhgpWc/giEZHlrpWuDv+9xro3tJccKVepL129/nWNBLVm6+0aoaJLERkU\nmbb2lO5LcoHdGs9yEAPcIKZZpJZ+Lk4cFK209nx6COFfa6xfCWwOIfyorZRJ3RnNhwvGpvWrOj4A\nsoKHiCw3reT8/tDM1gFXAv9K1MhlBfBzwC8Bvwi8GVDwa1O91pj90OJLgVFE0lq5J/TiTtZ0g5cQ\nwkuBdwLPImr88hPgh8D/IJrf71khhOuzTGSeJaOuJH7v4i1MTowPRCdSEemMPnjuzVQvHuRbncn9\nu8B3M06LNOC5W0/nq//+YK+TISIy0Aa6wYtz7k+ANxLlPgH+3Xv/W71LUXbKp/cx4Nz1q3ja5tO6\nlgYVaYpI1goGdebJ7oqBDn6xz3rv39TrRDSr1gwLcHLg6HQLznpjVJbPj1dNJ7o5iIgMElUciYgM\nmH5o7Nas4YJx2vjIoiEZeynrWR1GQwizWe6zAS91zj0POAi823uf+8Y2ytWJSL8pmDGxeoyjJxao\nXe7VHS0HPzO7BrgshPBw/PoJwFWAyyhtOOduAs6rsnob8DHgcu/9nHPuWcAXnHNP9d7vq7CvncDO\n0pu3bcsqmQNFgVFEuqWfZ3ZvJ+d3HfBdM7uMaEb395EKLlnw3j+jiW2/5Zz7AVHwXRL8vPdTwFTy\nempqqvePHm1S3Z1Ivoz0wdyU7ZqcGF8yr2gvtDOT+/uA1wLXAx8ALgohfD6rhDXCOXdW6u/zgAuB\n27qZhm4on4W9H2dfEJHOM7OBrO9LD6TfL7M9tFPsuQn4C+BTwJOAXWb2xhDC8WyS1pDLnXP/FzAP\nLABv9N7v7eLxM5Fu+VmpFagCnYgsJ/UG5++Gdoo9vwm8JYRwlZkNAe8FbgZqzfSeKe/9q7p1rCxZ\n6ne9stdGuy+IiAyKyYlx7tx/tHT/60X1TTvB75IQwl6AEMIC8BYze2E2yVrekiLMubgiOP0UlKxT\nbk9E8mC0R0M1thP8jpvZOWXLll19W6clZeHNVgCroYuISOvaCX7fIyq1M6JZHcaBQ8CGDNK17E1O\njLPv0EyvkyEikkstB78Qwunp12b2n4H/1HaKBsRIwZjLcIC64YIx3w8D3omI5EBmha0hhH8EVOfX\nooJZXzT/FRHJUvkg/Y2u67R2ujqckno5BDwdOKXK5iIikjP9XL3TTp3fI5ys81sA7gD+IItE5VXS\n+KXSxaIGLiIi2WlnhJdCCGEo/j0SQnhiCOFfskzccpaM0qIhykREuq/pnF9ZcecSIYTHWk/O8lTe\nmb1WGXf5HH4iIolB7v/bbw/5reT8HgEOx7/Lfw5nl7T82r1ze99dKCIizao2DvHundvZsmH1ojGL\nu63pnF8IQRPgtqlSYBvkJzoRkUHTdCAzs79O/f1r2SZHRESk81rJxT019ff/yiohg26owWlGhpfB\nfFwiIoOuleCXbruhO3kTjKgzu4iI9FYrwW+lmT3ZzC4AViR/Jz9ZJ7BfDeKEkiIi/aLXk3K30sl9\nJfCl1Ov03wE4t60UDah1q0Y4eHS218kQkWVMrcCz00prz00dSMeyVSt/qAtZRJa7fr3PtTO8mYiI\nSMt6GRgV/DosPWt7MnaniIj0ljqsd8Heyy9ly4bVvU6GiIjEFPxaNDkxXqrPU7tPEZHBouAnIiK5\nozq/PtGvLaJERJYj5fxERCR3FPxERCR3FPzaZNDTOalERKR5umt3Sa/HsRMRkZMU/DIwOTHO71y0\npdfJEBGRBqm1Zweo35+ISH9Tzi8jCngiIoOj73N+zrkXAu8CngR81Hv/prL1fwy8Jn75f7z3u7qc\nRBERGTCDkPO7A3gt8BflK5xzzwVeAVwAPBF4QRwsO273zu1VW3mODBXUAlREpI/1/R3ae7/Xe38r\nMF9h9cuAz3jvp733J4BPEgXDrlu/ZgxQ8aeIyCDo+2LPOs4Bbky9vhd4eaUNnXM7gZ3J623btmWa\nkBc+eSN/+uUfcXhas7mLiPS7ngc/59xNwHlVVm/z3t+fxXG891PAVPJ6amoqZLHfkaFCaVzOtStH\neGRmbtE69e0TEek/PQ9+3vtntPH2+4DJ1OtN8TIREZGqeh782vQ54C+dcx8mqhN8LfAnPU1RDZq5\nQUSkP/R9gxfn3CXOuQeI6ute55x7wDn3IgDv/Q3AVcBtwO3Abu/9l3uWWBERGQh9n/Pz3n8dOKvG\n+ncR9QPsG0k9375DMz1OiYiIVNL3Ob9BpYGsRUT6l4KfiIjkTt8Xew4yNXAREelPyvmJiEjuKPiJ\niEjuKPiJiEjuKPiJiEjuKPiJiEjuqLVnG9SPT0RkMCnnJyIiuaOcXxvUj09EZDAp5yciIrmj4Cci\nIrmj4CciIrmj4CciIrmj4CciIrmj4JexyYlxtQIVEelzCn4iIpI7Cn4iIpI7Cn4iIpI7Cn4iIpI7\nCn4iIpI7Cn4iIpI7Cn4iIpI7Cn4iIpI7mtIoQ+rcLiIyGJTzExGR3FHwExGR3FHwExGR3On7Oj/n\n3AuBdwFPAj7qvX9Tat2rgf8XuCdedNh7f3HXEykiIgOl74MfcAfwWuA3gNUV1l/vvX9xd5MkIiKD\nrO+LPb33e733twLzvU6LiIgsD4OQ86vnOc65W4Fp4APe+8/1OkEiItLfeh78nHM3AedVWb3Ne39/\njbd/GfgH7/2Mc+584GvOufu999+pcJydwM7SjrdtayfZIiIywHoe/Lz3z2jjvQdTf9/unLsGeBaw\nJPh576eAqeT11NRUaPW4IiIy2Pq+zq8W59zjU3+fATwP+EHvUiQiIoPAQujvDJBz7hLgU8ApgAGP\nAr/rvf+Sc+7/AX4NmCMK5B/z3v9Vg/u9GthXY5OnAN9vJ+3LmM5NdTo31encVKdzU10j52bSe/+S\nZnba98GvV5xzD3jvz+p1OvqRzk11OjfV6dxUp3NTXafOzUAXe4qIiLRCwU9ERHJHwa+6qfqb5JbO\nTXU6N9Xp3FSnc1NdR86N6vxERCR3lPMTEZHcUfATEZHc6fkIL93gnPsacCZQBI4Af+C9/4Fz7gZg\nkqjvIMCnvPcfiN8zDnwCeGr8vnd67z8frysQTaX0y0AAPui9/0j3PlH2nHOvAT4J/Lr3/ovOuQ3A\np4EnACeI+lZ+I9427+fmBnJ+3Tjn7iW6Lo7Fi/7Me3+Vrpua5+YGdN2MAe8HXgAcB2713l/Wi+sm\nLzm/l3rvL/DeX0hUeXpFat2bvfcXxj8fSC1/C3DCe7+F6B/1V865iXjdZcATga3A04C3Oud+vuOf\nokOcc5uA/8biYeHeA3zHe38e8BrgSufcSLwu7+cGdN0AvCx1Dq6Kl+m6iVQ6N6Dr5j1EQWqr9/7J\nRJ87Wd7V6yYXwc97/0jq5Vqik1/Py4CPxe+/B7gB+PXUur/x3i947x8GrgJekVmCuyh+cvrfwO8T\nPXElXsrJz/9d4KfA9nhd3s9NLbk4NzXk/rpp0bI/N865VcDrgF3e+wDgvX8wXt316yYXxZ4AzrlP\nA8ks77+cWvXnzrl3Az8C3uG9vztefg6Lhz+7N15Wbd0vZJzkbtkJfMt7/z3nHADxU9VI6sKE+p8/\nF+cmJe/XDcBn4vNyM/B2oiIpXTeRRefGe38gXp7n6+YJwMPAO51zzycqFv4T4BZ6cN3kIucH4L3/\nbe/92cAfA++NF7/Se78VuAD4JtEUSbnhnHsS8BLgT3udln5T59zk+rqJPTcutnoKcJBo/F2JVDs3\neb9uhonqPH/kvXfAHxDl1HqSCctN8Et47z8FXOycm0jmCvTeh7iS9NxUWfJ9RP+oxKZ4Wb11g+Q5\nRGm/I66k/wXgr4mKIOadc2emtt1EY59/WZ8b59zv6LoB7/198e854IPAc7z3h9B1U/HcxK/zft3c\nR1Q68FkA7/0PgHuAJ9OD62bZBz/n3KnOucelXr8YOAQ8Fk+DlCx/CfBQ/AUG+BzwhnjdZuAi4Iup\ndf/NOTfknDuNqNw5Xak9ELz3H/Xeb/Teb/LebyJq1PF/e+8/yuLP/1Tg8cCe+K25PTfA3+T9unHO\nrXLOnZpa9ApOTiWW6+um2rlxzg3n/brx0fyrXydqtJJ8zs3A7fTguslDnd9a4HPOuZVETx0HgF8B\nRoGvxE1vi0TFEy9Kve8vgE865+4CFoDf8ycnz/0MUbPbO4gaz0x572/rxofporcR1VvcAcwCl8VP\nspDvczOGrpszgKudc0NE04zdDfx2vC7v1021c6PrJvIG4BPOufcSnYfXe+9/4pzr+nWj4c1ERCR3\nln2xp4iISDkFPxERyR0FPxERyR0FPxERyR0FPxERyR0FP5Emmdn/MrP/nXr9bDMLZnZRatnHzOzd\nHTr+FWb2pk7sO97/hWb28rJlwcxOrfaesm03mtl3zKyQWrbGzI6a2SfKtr3AzK7NJuUijVPwE2ne\n9UQdbRMXA/9aYdl13UtSpi4EXl53q+r+B/CXIYRiatnLgO8B/9nMVicLQwg/BE6Y2fPaOJ5I0xT8\nRJr3HeBxZnZW/Poi4F3xb8xsI9GAuzfFrz9rZt7MfmhmXzGzM+Plf2NmyZQumNlmM3vQzEbin/eY\n2c1mdouZ/YOZrStPSK3t4hzix83s62a218z+0cxG43VrzOwqM/uxmX0z3u4KM9sQf5aL4/19LHW4\n342Pc4+ZvabSiTGzFUSB7uqyVa8jGlP3G/H6tL8HXl/jfItkTsFPpEkhhFng20QBYgzYHEK4Bjgr\nvvlfDNwUQjgev+VNIQQXQkgGNP6TePnfAq9O7frVwGdDCHPAW4HpEMLTQggXArdReZDtettdCPwq\ncD7R6CMviZf/T6JR9c8nmuXkmfFn2x+vuz6EcGEI4Q2pfZ0IITwNuBT4kJlVGiHqqcA9IYSZZIGZ\nPRE4G/gq0aSkryt7z03AJRX2JdIxeRjeTKQTkqLPfUTT1kCUI3xGvPz61La/aWavBFbEPwcBQgjf\nNrNhM3sq4ImGwfrV+D0vBtaaWRKsRommaylXb7svJIHIzG4mmlYGomDz5hAN8XTEzK4CttT5zJ+N\n0/1jM5sHzgQeKNvmLOChsmWvAz4dQlgws2uAj5vZ+SGE2+P1DwITZrYi9cAg0lEKfiKtuZ7opn4f\n0eSaEA3Ee3H882qIGsMQTd3yjBDCfjN7EVGxYuJviWauXg0cDCH8W7zcgN8PIXytTjrqbZcOJgtU\n/843Ms5hI/uaIQrwUeLMRoBXAnNm9pvx4nGic5cU+a6I9zfbQBpEMqFiT5HWfBfYAPwWi4Pfy4GN\nnMwNrgOOAIfi+rbyuq3PAL9BNODvJ1PLvwi82czGAcxs3Mx+vkI6Gt2u3HXAqyyymmgaq8RjRAPC\nt+KHwM+lXr8IuDuE8PgQwqYQwiai6aFeGQdGiIpe/62sgYxIRyn4ibQgrpe7EVgTQvhxvGwvsAa4\nMV4P8C/Af8Q/3ySatTq9n58SBcoXETX8SLyXKMD+q5n9kKhI9cIKSWl0u3LvitN6e5zGW4FH4nVf\nB8biBjofq/L+ikII9wAPpQLw64iLS1Pb3A78hJNFvL8EfL6Z44i0S7M6iORQnOsaCiEcN7NVRI1R\nPhxCaHueODP7DeCiEMIbG9h2lKi+83khhIP1thfJiur8RPJpHXCtmQ0R1bn9E/APWew4hPA5MzvD\nzAoNFGVuBt6uwCfdppyfiIjkjur8REQkdxT8REQkdxT8REQkdxT8REQkdxT8REQkdxT8REQkdxT8\nREQkd/5/LFXN2gh1fh8AAAAASUVORK5CYII=\n",
       "text/plain": [
-       "<matplotlib.figure.Figure at 0x116ef9780>"
+       "<matplotlib.figure.Figure at 0x1133310b8>"
       ]
      },
      "metadata": {},
@@ -736,26 +808,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
-   "metadata": {},
+   "execution_count": 22,
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "INFO:group_spectra.py:74:main: Starting at Sun Jun 18 11:20:38 2017\n",
-      "INFO:group_spectra.py:75:main:   using raw dir /Users/ioannis/research/projects/desi/spectro/sim/example\n",
-      "INFO:group_spectra.py:76:main:   using spectro production dir /Users/ioannis/research/projects/desi/spectro/redux/example\n",
+      "INFO:group_spectra.py:74:main: Starting at Tue Aug  1 16:51:41 2017\n",
+      "INFO:group_spectra.py:75:main:   using raw dir /data/desi/spectro/sim/example\n",
+      "INFO:group_spectra.py:76:main:   using spectro production dir /data/desi/spectro/redux/example\n",
       "INFO:group_spectra.py:197:main: Distributing 4 spectral groups among 1 processes\n",
-      "INFO:group_spectra.py:220:main:   (0000) Begin spectral group spectra-64-12609 at Sun Jun 18 11:20:38 2017\n",
-      "INFO:group_spectra.py:294:main:   (0000) End spectral group spectra-64-12609 at Sun Jun 18 11:20:47 2017\n",
-      "INFO:group_spectra.py:220:main:   (0000) Begin spectral group spectra-64-12612 at Sun Jun 18 11:20:47 2017\n",
-      "INFO:group_spectra.py:294:main:   (0000) End spectral group spectra-64-12612 at Sun Jun 18 11:21:36 2017\n",
-      "INFO:group_spectra.py:220:main:   (0000) Begin spectral group spectra-64-19435 at Sun Jun 18 11:21:36 2017\n",
-      "INFO:group_spectra.py:294:main:   (0000) End spectral group spectra-64-19435 at Sun Jun 18 11:22:14 2017\n",
-      "INFO:group_spectra.py:220:main:   (0000) Begin spectral group spectra-64-19438 at Sun Jun 18 11:22:14 2017\n",
-      "INFO:group_spectra.py:294:main:   (0000) End spectral group spectra-64-19438 at Sun Jun 18 11:22:25 2017\n",
-      "INFO:group_spectra.py:301:main: Finishing at Sun Jun 18 11:22:25 2017\n"
+      "INFO:group_spectra.py:220:main:   (0000) Begin spectral group spectra-64-12609 at Tue Aug  1 16:51:41 2017\n",
+      "INFO:group_spectra.py:294:main:   (0000) End spectral group spectra-64-12609 at Tue Aug  1 16:51:54 2017\n",
+      "INFO:group_spectra.py:220:main:   (0000) Begin spectral group spectra-64-12612 at Tue Aug  1 16:51:54 2017\n",
+      "INFO:group_spectra.py:294:main:   (0000) End spectral group spectra-64-12612 at Tue Aug  1 16:53:03 2017\n",
+      "INFO:group_spectra.py:220:main:   (0000) Begin spectral group spectra-64-19435 at Tue Aug  1 16:53:03 2017\n",
+      "INFO:group_spectra.py:294:main:   (0000) End spectral group spectra-64-19435 at Tue Aug  1 16:54:06 2017\n",
+      "INFO:group_spectra.py:220:main:   (0000) Begin spectral group spectra-64-19438 at Tue Aug  1 16:54:06 2017\n",
+      "INFO:group_spectra.py:294:main:   (0000) End spectral group spectra-64-19438 at Tue Aug  1 16:54:34 2017\n",
+      "INFO:group_spectra.py:301:main: Finishing at Tue Aug  1 16:54:34 2017\n"
      ]
     }
    ],
@@ -779,40 +853,46 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
-   "metadata": {},
+   "execution_count": 23,
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "/Users/ioannis/research/projects/desi/spectro/redux/example\r\n",
-      "/Users/ioannis/research/projects/desi/spectro/redux/example/exposures\r\n",
-      "/Users/ioannis/research/projects/desi/spectro/redux/example/exposures/20170615\r\n",
-      "/Users/ioannis/research/projects/desi/spectro/redux/example/exposures/20170615/00000000\r\n",
-      "/Users/ioannis/research/projects/desi/spectro/redux/example/exposures/20170615/00000000/calib-b0-00000000.fits\r\n",
-      "/Users/ioannis/research/projects/desi/spectro/redux/example/exposures/20170615/00000000/calib-r0-00000000.fits\r\n",
-      "/Users/ioannis/research/projects/desi/spectro/redux/example/exposures/20170615/00000000/calib-z0-00000000.fits\r\n",
-      "/Users/ioannis/research/projects/desi/spectro/redux/example/exposures/20170615/00000000/cframe-b0-00000000.fits\r\n",
-      "/Users/ioannis/research/projects/desi/spectro/redux/example/exposures/20170615/00000000/cframe-r0-00000000.fits\r\n",
-      "/Users/ioannis/research/projects/desi/spectro/redux/example/exposures/20170615/00000000/cframe-z0-00000000.fits\r\n",
-      "/Users/ioannis/research/projects/desi/spectro/redux/example/exposures/20170615/00000000/frame-b0-00000000.fits\r\n",
-      "/Users/ioannis/research/projects/desi/spectro/redux/example/exposures/20170615/00000000/frame-r0-00000000.fits\r\n",
-      "/Users/ioannis/research/projects/desi/spectro/redux/example/exposures/20170615/00000000/frame-z0-00000000.fits\r\n",
-      "/Users/ioannis/research/projects/desi/spectro/redux/example/exposures/20170615/00000000/sky-b0-00000000.fits\r\n",
-      "/Users/ioannis/research/projects/desi/spectro/redux/example/exposures/20170615/00000000/sky-r0-00000000.fits\r\n",
-      "/Users/ioannis/research/projects/desi/spectro/redux/example/exposures/20170615/00000000/sky-z0-00000000.fits\r\n",
-      "/Users/ioannis/research/projects/desi/spectro/redux/example/spectra-64\r\n",
-      "/Users/ioannis/research/projects/desi/spectro/redux/example/spectra-64/126\r\n",
-      "/Users/ioannis/research/projects/desi/spectro/redux/example/spectra-64/126/12609\r\n",
-      "/Users/ioannis/research/projects/desi/spectro/redux/example/spectra-64/126/12609/spectra-64-12609.fits\r\n",
-      "/Users/ioannis/research/projects/desi/spectro/redux/example/spectra-64/126/12612\r\n",
-      "/Users/ioannis/research/projects/desi/spectro/redux/example/spectra-64/126/12612/spectra-64-12612.fits\r\n",
-      "/Users/ioannis/research/projects/desi/spectro/redux/example/spectra-64/194\r\n",
-      "/Users/ioannis/research/projects/desi/spectro/redux/example/spectra-64/194/19435\r\n",
-      "/Users/ioannis/research/projects/desi/spectro/redux/example/spectra-64/194/19435/spectra-64-19435.fits\r\n",
-      "/Users/ioannis/research/projects/desi/spectro/redux/example/spectra-64/194/19438\r\n",
-      "/Users/ioannis/research/projects/desi/spectro/redux/example/spectra-64/194/19438/spectra-64-19438.fits\r\n"
+      "/data/desi/spectro/redux/example\r\n",
+      "/data/desi/spectro/redux/example/exposures\r\n",
+      "/data/desi/spectro/redux/example/exposures/20170615\r\n",
+      "/data/desi/spectro/redux/example/exposures/20170615/00000000\r\n",
+      "/data/desi/spectro/redux/example/exposures/20170615/00000000/calib-b0-00000000.fits\r\n",
+      "/data/desi/spectro/redux/example/exposures/20170615/00000000/calib-r0-00000000.fits\r\n",
+      "/data/desi/spectro/redux/example/exposures/20170615/00000000/calib-z0-00000000.fits\r\n",
+      "/data/desi/spectro/redux/example/exposures/20170615/00000000/cframe-b0-00000000.fits\r\n",
+      "/data/desi/spectro/redux/example/exposures/20170615/00000000/cframe-r0-00000000.fits\r\n",
+      "/data/desi/spectro/redux/example/exposures/20170615/00000000/cframe-z0-00000000.fits\r\n",
+      "/data/desi/spectro/redux/example/exposures/20170615/00000000/frame-b0-00000000.fits\r\n",
+      "/data/desi/spectro/redux/example/exposures/20170615/00000000/frame-r0-00000000.fits\r\n",
+      "/data/desi/spectro/redux/example/exposures/20170615/00000000/frame-z0-00000000.fits\r\n",
+      "/data/desi/spectro/redux/example/exposures/20170615/00000000/sky-b0-00000000.fits\r\n",
+      "/data/desi/spectro/redux/example/exposures/20170615/00000000/sky-r0-00000000.fits\r\n",
+      "/data/desi/spectro/redux/example/exposures/20170615/00000000/sky-z0-00000000.fits\r\n",
+      "/data/desi/spectro/redux/example/spectra-64\r\n",
+      "/data/desi/spectro/redux/example/spectra-64/126\r\n",
+      "/data/desi/spectro/redux/example/spectra-64/126/12609\r\n",
+      "/data/desi/spectro/redux/example/spectra-64/126/12609/spectra-64-12609.fits\r\n",
+      "/data/desi/spectro/redux/example/spectra-64/126/12612\r\n",
+      "/data/desi/spectro/redux/example/spectra-64/126/12612/spectra-64-12612.fits\r\n",
+      "/data/desi/spectro/redux/example/spectra-64/126/12637\r\n",
+      "/data/desi/spectro/redux/example/spectra-64/126/12637/spectra-64-12637.fits\r\n",
+      "/data/desi/spectro/redux/example/spectra-64/126/12639\r\n",
+      "/data/desi/spectro/redux/example/spectra-64/126/12639/spectra-64-12639.fits\r\n",
+      "/data/desi/spectro/redux/example/spectra-64/194\r\n",
+      "/data/desi/spectro/redux/example/spectra-64/194/19435\r\n",
+      "/data/desi/spectro/redux/example/spectra-64/194/19435/spectra-64-19435.fits\r\n",
+      "/data/desi/spectro/redux/example/spectra-64/194/19438\r\n",
+      "/data/desi/spectro/redux/example/spectra-64/194/19438/spectra-64-19438.fits\r\n"
      ]
     }
    ],
@@ -830,25 +910,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 24,
    "metadata": {
     "collapsed": true
    },
    "outputs": [],
    "source": [
-    "specfilename = desispec.io.findfile('spectra', groupname=19435, nside=nside)"
+    "specfilename = desispec.io.findfile('spectra', groupname=12637, nside=nside)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
-   "metadata": {},
+   "execution_count": 25,
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Reading /Users/ioannis/research/projects/desi/spectro/redux/example/spectra-64/194/19435/spectra-64-19435.fits\n"
+      "Reading /data/desi/spectro/redux/example/spectra-64/126/12637/spectra-64-12637.fits\n"
      ]
     }
    ],
@@ -859,8 +941,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
-   "metadata": {},
+   "execution_count": 26,
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [
     {
      "data": {
@@ -912,7 +996,7 @@
        " 'wavelength_grid']"
       ]
      },
-     "execution_count": 25,
+     "execution_count": 26,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -923,16 +1007,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
-   "metadata": {},
+   "execution_count": 27,
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "(dict_keys(['r', 'b', 'z']), dict_keys(['r', 'b', 'z']))"
+       "(dict_keys(['z', 'r', 'b']), dict_keys(['z', 'r', 'b']))"
       ]
      },
-     "execution_count": 26,
+     "execution_count": 27,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -943,24 +1029,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
-   "metadata": {},
+   "execution_count": 28,
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<matplotlib.text.Text at 0x11b160828>"
+       "<matplotlib.text.Text at 0x11177ddd8>"
       ]
      },
-     "execution_count": 27,
+     "execution_count": 28,
      "metadata": {},
      "output_type": "execute_result"
     },
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAZUAAAEKCAYAAADaa8itAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAIABJREFUeJzt3Xe8HFX5x/HPQyK9BgKGEhKkKKAEciXSg5RAQBAUJaLS\n4Yf8BFFQsIEiTQT0J0UCJhRBqQEEpQSpoYYQeg0tCYGEGsAAKc/vjzObnbt3y+zu7M7u3u/79drX\nTtvZZ/bunWfnnDPnmLsjIiKShkWyDkBERDqHkoqIiKRGSUVERFKjpCIiIqlRUhERkdQoqYiISGqU\nVEREJDVKKiIikholFRERSU3frANopJVWWskHDRqUdRgiIm3lkUceecvd+9fy2o5OKoMGDWLixIlZ\nhyEi0lbM7NVaX6viLxERSY2SioiIpEZJRUREUqOkIiIiqVFSERGR1CipiIhIapRUREQkNUoqRXzy\nCVx0EWikZRGR6iipFHHCCbD//jBuXNaRiIi0FyWVIt54Izy//362cYiItBslFRERSU3LJRUzG2Nm\nM83sydiyfmZ2m5m9ED2vkGWMIgI8/TRsvz3MmZN1JNJCWi6pABcBOxUsOxa43d3XAW6P5kUkS0ce\nCbffDvfem3Uk0kJaLqm4+93AOwWLdwcujqYvBr7enFia8S4iIp2j5ZJKCau4+4xo+g1glUa+mVkj\n9y41+/BDFbWItLh2SSoLubsDJa8hzOwQM5toZhNnzZrVxMik4ZZZBtZaK+soRKSMdkkqb5rZAIDo\neWapDd19tLt3uXtX//41DVwmrSzX3ltEWlK7JJUbgH2j6X2B65vxpqpTERGpTsslFTP7O3A/sJ6Z\nTTOzA4FTgR3M7AVg+2i+gTHkp+fPhwULGvluIiKdo+XGqHf3USVWbdfUQCJ9+8Lmm8OECVm8u4hI\ne2m5K5VWdN99WUcgItIelFRERCQ1LVf81UpUUd8i5s2DmSUb/IlIC9GVShG6+bE1fPGLsOWWhO5A\nVlst63CkFP36khhdqUjLejLXpeirN2Qah4gkpysVEamPLu0lRklFWp9OWo13G/Ba1kFIJ1DxVxkq\nKm4RSiqNtyOwDDA760Ck3elKpQidw6RX+iDrAKQTKKlI61OWF2kbSioiIpIaJZUiZkflyg8/nG0c\nEnn11awjEJGElFSKyHUeecEF2cYhItJulFSKUBG+iEhtlFRqcNddMG5c1lGIiLQe3adSRKUrleHD\nw7PuYxFB/wjSja5UilDxV+e48EK45Zaso2hx82t8nf5RpAhdqRSh/5XOcfDB4Vk/psv4tMbX6UOV\nInSlUoSSikgV9A8jMUoq0n4GDYLLLss6ChEpQkmliPlFypinTw8/yB58sPnxSIFXX4WDDso6ChEp\nQkmliKlTey476qjwfO65zY1FRKSdKKkkdNVV4fmSS7KNQ0Q6hANjqL2hRItSUpH2pMrh9KgRVzau\nAg4ETsw6kHQpqYgk4a4mtJKud6PnmZlGkTolFZEkdtoJFtG/Szfjx2cdgbQg/ZeIJHHrrVlHINIW\nlFSkPc2ZAzM7rNygXalYUGKUVKR9/elPiTctdu+RiKRPSUV6hd//PusIRHoHJZUUTJqk8VVa3fPP\nZx2BSAkdVnrYdr0Um9krwAeEDrvnuXtXlvG89x4MHRqmVbTcuvS3KWNyna/XPUMS03ZJJbKtu7+V\ndRAAq66adQS9mE5m6Xgz6wB6uQ77GtdU/GVmS5lZn7SDaUdz5mQdgSShKxWR5kiUVMxsETP7jpnd\nZGYzgWeBGWb2tJmdbmZrNzbMbhwYb2aPmNkhRWI9xMwmmtnEWbNmNTGs0t56C/bbD/7736wjESlC\nCTdbHfb5J71SuQP4HHAc8Fl3X8PdVwa2BB4ATjOz7zYoxkJbuvsQYGfgcDPbOr7S3Ue7e5e7d/Xv\n379JIZX3y1/CxReHh2Tjww+zjqCFXVnn6085JZUwep0OK/bKSVqnsr27zy1c6O7vANcA15jZZ1KN\nrAR3nx49zzSzccCmwN3NeO9a5YpeclUAb7wByy0HSyyRXUy9QbzI68UXs4uj5d1T5+vvuCOVMHqd\nDrtCyUl0pVIsodSyTb2iupxlctPAjsCTjX7fpHbYoXzZfS6pDBgQtpXGOuGE/LTqVKRlddgVS8Wk\nYmY7mNkFZjYkmu9Rj9FEqwD3mtljwEPATe5+c1bBFDY+Gj8ePi0yNkKxE9qECY2JqVep0Ppr9Oj8\n9BNPNDiWdqaE21wXAWfG5jvs809S/HUAcBjwSzPrBwxpbEiluftLwEZZvX8SuQTiDhddBN/+Nlxw\nQVimFrDNc+WVoZhRpG4PA3sCTwDLp7C//aPn81PYVwtKUvz1gbu/5+5HE4qbvtzgmDrC+PFwwAHw\nhS9kHUnvdN55WUfQRvRjp7wTgGlA2qULHXaFkpMkqdyUm3D3YwENqJtArrXRa6/llyW5Ujn0ULjh\nhsbEJCJ1aFQSMMINqA2vlW6OiknF3a/PTZtZF/BVM5tkZo+b2RNm9nhDI2xTxZqwJkkqo0fD7run\nH09vo6LGKryedQAtrtHfpf8CnyVUMnSAau+ovwwYC3wD+Bqwa/QsBX73u6wj6CXmzYN994Xnnss6\nEmmW/xBO9C3T7rNGuWSVuym6Qzqlrbbvr1nursKZCl5+uXivuPr13ACPPAKXXALPPgsPPph1NNIM\nV0fPdwEbNvF90y7+yu3PCubbXLVJ5XgzuxC4Hfgkt9Ddr001qjY3Zkzpdeeck5++8UbYddfGx9Ox\n4lm6oN22EniNPgSWzjqICgpPxo10K9CoVoTvR8/XNGj/Gak2qewPfB74DLAgWuaAkkpk/vzSfXyZ\ndS8W+9rXSt+UN2cOLLIILLZY+jF2DHdlj7RNAEZkHUQFhUnlQ2DRaP5lYN0U36uRn8WjBfO99Erl\ny+6+XkMi6RBjxsCZZxZfd955YfyVJJZcElZbDaZNSy+2jjNmTMjMoCuVRpo+PbSR33ffrCMJCpPK\nMsAwws0OZxOa/66WQVzVSlqj/VtgA0JNdhuotqL+PjNbvyGRdIi33y69buJE+Pjj7svOPbf09tOn\nl143fz7ce291sXWc11/PZw/1w9I4O+4Yutl+992sI+ku/sPhQeDOaPqdBr1f2l+xUj987iZfDgRw\nPPBNQjHcMGBGynGkrNqk8hVgspk9pybFxf3mN9Vtf/jh+a5d7r+/5/pPPw0JpNBJJ8FWW8HdLd2V\nZnYeeyzrCNrUy0BhV0O5rgkWLCjcOhtZ/X44m5AI0voYCpOKAzcD2wBnFNn+fELnVH9J6f0bpNqk\nshOwDuHOejUpTsmxx4arks0377luscVg++17Ln/qqfD8uu4xAOCTT8NFy4QJIQm/1RLjgrahw4BW\nr8drZkV93G3Rc5H+/RKL17cWi39q9FyuhXyLX5RXlVTc/dVij0YF11ucdRasvnrp9Xfe2XNZrtTn\nttt6+eiTUZcFH8wO/2m//CX0bddBsiWZeFJpt3FyDoxNF7aAdyD3v1wscbVJPWFVScXMLjaz5WPz\nK5hZmQa00mhjxoQitDS89Vb5OqGWlLtkixRLwFKDeLl9q9VXxZNKse5lGx1uPft/OjZd5F42csXn\nl1bYz1RCXUuL/Wmg+uKvL7n7wvZL7v4usHG6IUkS8dZNY8fWtg93OPFEeDW61uzfH1Zaqf7YFizI\n77Phjj8eAGvWiW/OHPjDH2Dq1MrbtrN4K8XcZxuvqD/1VGBtYFDzYroe6CJfp2HAS7H18+rY96fA\n6YT+t6YCo4CPy76iNuW+pk734rFXCrZ/Njb9TUKrsMmpRZaaapPKIma2Qm4m6gpfhQ1NcsQR8I9/\nhOnCJrMffxx6RL7sstKvX3JJ+EasWeLzz8Ovfw177JFunKedBoMGNbvnFKcP8+jDPMBZhtmNeZvj\njoNjjoGBAxuz/1YRbxySawf/gx+E57lzw+fAC4Sa/Sb5DvAI3U+8cbmTbi3FwX8EfkqojD8C+Aex\nrnRTVGlcn/j/9WDgrNj832PTD0XPhd3nzyLc//IQmak2qZwBPGBmJ5rZicB9wO/TD0uK+fOfYdSo\n4uv22y/0VPL974f5eIuxKVPgmmvCj+xrY7ep5rYpVSfz6KPwwgvVx/mf/4TneA/NzfAc6zGPz3AN\n32A2y/F9Lk7/TZK2AJgwAW6/Pf33r8WCBfB//wcffQTvv195ewgnWOjejO6DD8Lzppsmf++5hCuA\nT4DHCHmoXpUq6mtJKrnfIB8B10XTWfQaXHhGLta6M371Ev86zgNWBjYhND3OSKKkYmabmZm5+yXA\nHoSOmt8E9nT3SqV/0gRXXBGezWDSpFBZbQazZsHaa8M3v9nzNQ8/HJ4XKfEt2GQTWLfI3cnTppW/\nIsopLJF69lmY3aALiP/+Fz4XlYXsGfXMdzH7LVyf2pVL0mK2Lbcs3myvkj33hM9/Pj9/7bXhD1nu\npqVybr89JJQjj4SNN4bll09W8fTv6HlIbkw+g4/XDJOTy5S5HEIoOsoZTUhQpxOG96vnbvdcEllQ\nMF9oJtUXhRX7s5b6UdTIktbCY6pUOR+v7K+n+C9FSa9Uvg88Ymb/ADYFrnb3s9396Qqvk5S8+GJ+\n+p13St9pP38+DB2any91/njkkXB1A9Xffb7ddvDd74Z9mMG//919fbFu/yEUz9Vynk1ijbeKn+gm\nMpTvcBmzWa6xHU7OnAkHHdTz7tZqjRvXvdwwN2zo4zXeDrb99nDUUWE6d9lZ7IaokvYh3EFwDEz+\nR/ky/NeACwhFRzm578IHVbxlJZWuVL4NHFnm9fPoeRVycpF9lkoejUoqTs8zcqUeNaaRL/ZrkUr7\nREnF3Q9z900IY6CtAFxkZveb2clmtrWZ9WlkkALrrJOfXnFFuOeeZK877riey669Frq68vNz58Ju\nu+XnR44MPS3H3XknLLssLLpovgfmXAwjR+YT2S23wAMPlI4nd3XULEOZxLGcGmaOPhp+X2dp7ZMl\n+ls/+mj461/DOMalzJoVsvCNN9YXQ72q+hXxN+AW4LQw+/wnpTf9fmx6DbpXt6R5wktyn0qpnire\nJfRcuGiJ9fF9nlZlXPVy6HFBPTHB624Dfkd6N2XWqdr7VJ5197PcfSfgq8C9wF70bHEtLWLKlJ7L\nCk/6zz8P//xnfv7f/4add87P33gjbLttKFKfG/uFF7/BetKk8Jw02RW69dZQBzNvHvztb+nevD2f\n6DfPvffCz34WpqdNC03fcsVZ7qWvBuIHHd9m7NiexWHlisdyxUZ/+lPy4BvpvffKV5r9q8ixfPtb\npbeP/82mAWsBx0bzhdVLc6n+6iWNLuKLNeMt9h4QElAzfZRwu8LjPwL4VZHlGam2on4hd5/j7v9y\n9x+6e1flV0irOP30ytvES2COOKL4Ns8+233eDC6N1bDl6nn+85/Q71mce7iKeu65sP8RI+BLX4Iz\nzoDvfS8klrT0oaCfm513hjXWCE3fnoia45x3Hmy0UQh2n33CwVxzTbibctESP2sPOGBhk+aq+iAb\nP7785Vxcbn+FVxevvQY//GHxPnwquf9+eOYZGDaseKVZzi7lLgW+3HNRuc0nFcx/A1i2zPbl5D7i\n68puVZt2uMGw1GBeLZJUcPfED8JVyTLR9K8IXd5vXM0+mvkYOnSo1yL8J+uRxmPs2J7L3N2vvrr4\n9p/7XHju2ze2faODHD7c/eCDw/TgwdW/Pv6lGTOm+3zcaaflly++uPuCBaW/fDkjRoT5U05x//TT\n/PJttgnL7747hS+zV/HYzZ1Vey4fU8U+vGD+iPKHsNDS0fa7VfE+hcaXWJ9bdkqC/X6QMN5iqvqs\nq3y8VzBfT5gwsdZIqtsYHo+etyT0CboL8GCDP6qaH0oqrfm48MLqts884EqPSZPy03/9q/uECfn5\nBQvc77yz+Oseeih84V5+2f2OO9wffjh20N59P+B+1FFh+eOP55fdfbf7JZe4L7NM96RT1Ze5mv+q\nn1W5fZGHl1hWzoLYtl+r4n3i7iqy/sWCeE5NsN+p7n6zu/8gmv9JbD+V1PvZlXvMqnD8VagnqVR7\n42LuWnsXYLS732RmGo1dqnLQQVlHkLJNNslPu8MWW+TnDzgALrqo+Os+/TQUv33pSz3Xvf129/1A\nvvVafPtDDw29CH/wQXj069c9ltSd2oB9xjj5QvlPCZXq0L2gvtbD2qZgfnPgfrp3iZKk+GsvIF56\neUb0yMV1F6Hu5uDawqzZ1ZU3aYZq61Smm9n5hEZ7/zKzxWrYh0jnKryfpFRCgXAjYrGWFJC/izXu\nvvt6LnvmmXz3KfF6lxkzuie7VlLuxB1vQluqoVlajedyLavj9X0/S/C6StVhwwn36wBMp3RLtLSV\n6mmgyaq6+RH4FqF94QgPfYD1A45pYHwi7SVXcZ/EkUeWvpr417+KLy9392i/fqEZ3pQpsNlm5W9S\nbDV3A3vSM5E8S/1jxL9N+V/xaf0s/mLB/DOEgUEOJyTSRned8pMG7z+hpMVf3wfOIVzU3UzUGNDd\nZ9Dy45CJtKiZM6sfTfHQQ8uvj9/52k5yRVPxlk3XAd+rY59rEu7fuJDi3Z3knFVmXTWepHvT6cIx\ncjPsOqWZzKsodzWzzwM7AyOA5YA7CElmgrvX0Laxsbq6unxiYVvWBDS+eWvxtmjn2c4aUfcimZsF\n1NjruJk94jXeKqKbH0VEOlGR3jSaoarWX2b24yKLJwN/TSccERFJxYWEvtiarNoqqi7gf4DVoseh\nhHHrR5vZT8u9MA1mtpOZPWdmL5rZsZVfISIizVRtUlkd2MTD7T4/AYYSevDfBmL9jDdA1GnlOYQ6\nnfWBUWZWWBUmIiIZqjaprEz3Rn9zgVXcfQ6lW5WnZVPgRXd/yd0/JXSwvXuD31NERKpQ7R31lwEP\nmtn10fzXgMvNbCmg0WOrrEYYPTpnGr2mkZ6ISHtInFSimx8vIowJl+s/4n/cPddmd590Q6uNmR1C\ndD/rwE4fR1xEpMUkTiru7mb2L3f/IsmGjknbdMLQPzmrR8u6cffRhEFM6erqUgN8EemdqhngM0XV\n1qlMMrMiAyk0xcPAOmY22MwWBfYGbsgoFhGR1rZkNm9bbVIZBtxvZlPM7HEze8LMahw8uzruPg/4\nX0LfY88AV7r7U814b5G20KWx8noYCLxJ99pYaahqK+pHNCSKhNz9X0CJnvZEerH994cxY9THUNxH\nQB9gsTLbHELodbjRP41PI1kPyGnKqPC/2m5aXi32aFRwIr3Cb39b+2sXWwxuvhn+8pcwf+216cTU\nTKsQOnw8m9CG9GXCePcee9RiSconFIDzgaNq3H8559C9y/slCcMa9gJVJRULvmtmv47mB5rZpo0J\nTaSBrroqP11sDPp58/LLzz472T5vuimMG1+N+fPhV7+q7jU5P/4xfPwxjBiRj3WPPUJ3+rNm9Rzk\nK1UplTyfRujafitCF/FfAAbR3LHi+8Sm6+3k+Vjg78APgMOAK2P7LRwkrENVW6dyLrAZMCqa/4CQ\nk0WK2nDD7vO5c9/hh4fnVVYJz5deCk8+2by4+OY389MTJ8JvfhN+8b/5Zjgp9+kDL78M994bpsuZ\nOhXuvx9Gjqy8bZw7LBL9C/7yl3DPPT23GTsWTj89+T5zVloJLr88P3/zzXBWWn28A5RJnhslePk5\nwD3A0XWEMKDE8m2Bi6vYz2di059PsP3iRZb9jnCzxSmEJkQ5ewFvEc6azVY4vkuzVDP2MDApen40\ntuyxWscybvRDY9SXfxxxRPn1q67qfswxlfdz3nml1x12WH76+efd77knTE+e7L7yyu433VT8sx8y\nJD/dkIOPv1klc+bktx05Mj99wAHuLxYMTn7UUdXFUOiOO9y//OWwfu+9w7IpU4q//sQTy8c9d273\n9/rzn8P0wIHur78e25fX8Nim9Lp/Jnj99ZU+9ALF9nFMieXnJ9zH3Gj5VbFl+xTZbpOC+SUL5k+u\n8ziSPNaLTa9UYpsjC+brQB1j1Fe3cejivk8sufSPJ5hWeyipFH+ssYb7+uuHYx0+vOf6DTd0v/zy\n/Ofxxhul97X77uGce+ed7iNG9Fz/29+G529/O9lnf+ml7sOGdf87pP4BmIU3eOkl95kzq/tSvP12\nLLAiLrig9Pvutlv3+VJyWfrQQ8N8LqkMGhQ+6DfecP/jH90/+aR8zPPmdX+vadPcV1zR/emnw/zJ\nJ3v1SeUL7lzvzqLu7O7O0WH5CHf/sbtP9uYllZ+WWH5ZiX1sXbBdztWxZWOL7K8wqSxRYj+1HkeS\nx/ux6bfdfW13/3XBNh/XEVdhmE1MKvsQ7g2ZBpwEPAfsVcdH1dBHJySVxRdPf5+vv54/1ksv7bl+\n5Mjun8fHH3dfP2BA+EF9fZETQ+G+Pv3U/Yor3BcsqP3vkMZBr85r7q++GuZr+V7ET87lksKCBe79\n+hWPY//9u8+Xcs45Yf1hh4X5F18M84MHVxfz/Pnl32thgvQqHoXHtZMvTCo5NybYz3XVHUpVSeXx\nEvvYpmC7nGsKlhXurzCpLF9iP7UeR5KHu/sJ7n53if0V238d6kkq1bb+ugz4KaHkcAbwdXe/qvyr\npB7rrVd63XLL9Vw2ZUrp7VdeOTzHW52699xu7NjS+/jDH+Duu2H4cNhtt57rc2ebnM98Br71rca2\ndD2FyqMgTGMNGDgw1JHcemvjgjGDr3wlTI8dC2uuCbvuWt0+FizI7yv+XKxBQaVYINSvFNOvX/Ev\nQDd3VVjv3Z4SW6HK7ZPYDniE0nUJO5ZYXu67Ga8iu51wQ8M/yaaO5HhCg4YWV21FPR5GfzzH3c92\n92caEVRvUu48seaacN11pddPngxXXw1rrx3mn3gC1lqr53b77Qc/+hEssUSYL3aCXyPWAU4u+eTk\nznGLLQY/+Un+/VrF3udsnXzjLbYIJ9NGOvdc+M53YNQoeOUVWL/KERpyJ/pcJf7gwXDccXDjjdXt\nxyzsa9as6l7Xze+rf0mlezCvBqr4kyXWB9ikzPpjCf2sJzWTUMmeS5jLEQbe2BK4D3iVbDqsKlSs\nwUKxxgRNUnVSkXSdeWbpdWefDYMGhXNUzjmxtnaDBsE3vlE6MT36KLz2WvjBfNZZcNttcOKJPZMG\nwNZl/slzSaWahk3NNPh/8vfkvtOQn8BVWnNNuOyykIXjch9kJfPnh+dcUjGDk0/OKJvnYr4LXgcO\nOKDyS1YBvldm/TfqjwqovtnxIoQeA5PqDyxf5v0GUn8T5HrNAp4vsvyFZgeSp6SSsaWXLr1ul13C\n82GHJdtX7grkj38Mzxtu2P0KZJ11QsvV+JXKaquF5y98ofL+l1++8jaZWCT/NT6SPzGbZXiZQQBM\nYS0ODv2LZqdiEVOBIUPC85Zbph9LNVaPd6333/CLuMexlCj+ys0f2IC4Tk5hH5elsI9WsBJQ7BxS\nTfJMWcWkYmb3mtnB0ZgpkrK+fbtficQVK6YqVzeR+38/8sgw3TdBJzxf/SrceScce2x4PuGEntss\ntRT86U+hLiWpE04IV0bN9je+x3LMZhMmsR7PsjZTuJCDmx9IMUmTy/Dh8PrrsNdeDQ2nIgPOKfHl\nXKjEMeWKZL6eYjxpitdVtmrPNq0aVwVJ+v56hlC6OMbM3gPGuvsDjQ2r96j2R2wjbLNN/jk3XeiI\nI6rb5/HH1xdT1R54gF2+8tbC2fdYgfcaVRQ2YADMmFH963KVWknfI2tuMGowHP4+obHnzqV/1RR+\nj08k3AS5S0qxfI1QQV6vMcCvqHxj4Lax6Rb4H20nSZLKPHe/HrjezNYgXNAqqaRkwQLYaaf8/E03\n5Yu9isn9Txe7CunVfQkOG9a8nkYnT4Zp06p/3Vprhb65+vevLsFkxqJWWrFyz6TFX4vRc9i+l4D5\nNYZyEXA6IVnlOhio5fu+EaUHzMgVAX9I8T7DevP/VxWSJJWFpY/uPhU4oWHRdIiNNoLHHku2bZ8+\noXFPzsiR5bdfZ53wnKs3kSaZPh0++ihMr7xy8dYOpcRPxHvskW5cjWQp/UT/C7A2MLjShmX0I9zI\nAI27coj+tygs6D+IMOjGGkgCFetU3P3eZgTSST6fpP8g4Gc/C/dwVGO77WDSJPjBD/LLRo+GzTbL\nJ5zeaurU0OKtIVdsq65a+wecS0ArrphePA03Dda9JEweFevGt5YP91DCPSRpS+vvvC2hjuU3JdYf\nTkhkJW73qVm55s9trOrWX2bW7FEB2k7S/7tTTw03Bya17LLheeONu7/HFlvAffdVf29cp1l99dBw\n6uOPs46kwFFHhXbd+++fdSRV+F9YNLoyO/PM/NVWj+aKNd782EqWA54FhjTxPb9LSFYdqGLxl5ld\nGZ8lfPSnNSyiDvfjHxe/N+Vb34IvRwM133FHaIkVN3p0aBQklbVccu3bN9yB2m6K/To66aRwh/6v\nfx0taOdskiGnYz+6JHUqs939oNyMmZ3XwHg6QrkWXdtuWzypXHFFfnr48J4J5OAWaRUrvcXzFK0E\nWXrpMP7LwqQSaeYJslNOxpWOwxJs04KSFH+dVDD/i0YE0ql+/vPuv5yr7QZKpOn2eY5wJ0ESGRZ/\nGbADsCih65QzMoihHpU+s1a92biCJBX1LwOY2UrR/DuNDipr9d45Hi81OOkk+OST+vbXW02cCA/U\n2Hi90d17dbQ1Z4fnRJWDURvhKuoG6xY/Gd8KfEIY8GvD4pu3pMLir8JGAovRtjduVFNRP6ZhUbSY\nUjcAVmPjjevfR283dCgMG1bbaxvZEXHHWxCd7RIllXvg4PfCfSRSnXhS2aFg3Q/IN3FuM9UkFd36\nk9C668KDD7ZgK6RO8pOflF29eIa9tHaMckll9VznUg4/fw9WbUpE7e/U2PQGCbZvh3tkCySpqM9p\nwyqj5hs/PlzpJOl3S+qQ60QySU+YUp3cZ1uuGd0TT8AKGfcI3Y4/c1eLTefuZ9uO0h1yvgK82+CY\nUqYrlZRtt50SSlOYhRPbhAlZR9J5NtkYjj4azivT0HP55cOgZ1lo55+38bPoSsAthPFlSh3TynTv\n/LINVHP6O65hUbSYRtyR/fOfqzgsdRu2U81sG1mkD5x+euXtcrLqdK4TfubmRqNs0bGKalFNUpkX\n3U2fu4CrgSuDAAAQ00lEQVSbDtyg0R+TOamwYbbUp8KJbPWC8STaqoeUdjF4cBgFrtl3m+aG1G3E\n6JHNUnhlMozQq+JH5DvMbFOJir+iZPIPwm+Dh6KHAX83s8oDhHeocqM2lvOXv4SSG6lDhTEDlluu\n+/wiGo4uuWUSbnftteHR7G76hwMf0LPFVDso9VvICGPQt8CIB/VKeqVyILCBu8+NLzSzM4Gn6N6m\nodc46qjQ7Uq1Dj00/VhEUpO088d+/bLrdbnMiKltLddp5Sp17CPjZJv099sCijcaHEB+EOte6fLL\n4eGH4eutOsJdp+rVg8c0mD7axit1ob0PcClwdI37fQm4rsbXpiTplcqPgNvN7AVgarRsIGGUhP9t\nRGDtYtSo8DxuXLZxiKTi8qwD6OUWIfRgXKt6xqxJSaKk4u43m9m6wKZ0r6h/2N1rHcstMTM7ATgY\nmBUt+rm7N2ygP/0Ill5rVNYB9BIdfI5J3PrL3ReQbW80Z7n7HzJ8f2ljFer1RZqrg7+PdbeJMbN2\nGnlIepFNOnRkPWljHXyFkpNGQ8tSg3Cm7Ydm9riZjTGzjPuHkMwlKKO8/Xa4NxoMOzcAmog0VqLi\nLzN7vNQq6mv8Fn+P8cBni6z6BXAecCLhovFEwsgJB5TYzyHAIQADs+pGQhpvlcpfu+WXD0MtP/SQ\nugiTFtPBxV9J61RWAUbQs2szA+5LIxB33z7JdmZ2AXBjmf2MBkYDdHV1dfCfrpf74Q8Tb6qrFGkZ\nvaD4K2lSuRFY2t0nF64wsztTjagIMxvg7jOi2T2AJxv9ntLi+nRQZ0mt4otZByCdIGmT4gPLrPtO\neuGU9HszG0K4aHwFyPye9K99LesIRFK2btYBSCdIWqdi7uUbZSbZplbu/r1G7LdWap4qHeVHwB+B\njbIORDpB0tZfd5jZD82sW823mS1qZl81s4uBfdMPT0QabqmsA5BOkrROZSdCa6u/m9lg4D1gccIo\nALcCf3T3RxsToog0RS+oRG4ZHVzakbRO5WPgXOBcM/sMoS/NOe7+XiODawUrrADvttlwnh3vtNOy\njkCkNr0gcVd986O7z3X3GZ2cUOL31V2XcY+fUoRuOklXB/9qlubT0EUVbL01rBcbI/pHP8ouFpGG\n6gW/oltGBydyJZUE4lcuK61UejsRkbJ6QeKuKqmY2fpFlg1PLRqRJDQ2Qbq2jJ6/kmkUvUMHX6Hk\nVHulcqWZ/cyCJczsz8ApjQislegcJh1tZ+Btkg8jLFJGtUllGLAGob+vh4HXgS3SDqqVDRmSdQQi\nDdAv6wB6iV7wA7XapDIXmAMsQbhP5eVo8K6OUu7KZJddmheHlKBLR5GWVW1SeZiQVL4MbAWMMrOr\nUo+qxegclrF++hktHaaD61YSDyccOdDdJ0bTM4Ddzayl+uVqBPX11WKWXTbrCERq0wt+oFabVEaa\n2ciGRCJSSuGl4lZbZROHiFRUbVL5KDa9OLAr8Ex64YgUoUtF6TQd/JWuKqm4+xnxeTP7A3BLqhG1\nINWpiIgkU+8d9UsCq6cRSCvrG6VeDcyVEWV16TQd/JWu6krFzJ4gf+HWB+gP/DbtoLJWeA7LjVx7\n/PHNj0VEOpCKvxbaNTY9D3jT3eelGE9L0g9lEUlFLziXVFun8mqjAhERkfaXqE7FzD4ws9nRo8d0\no4PM2rnnwrBhsMEGWUciIh1BxV9s2JuvUoYNgwceyDoKEWl7vaD4K2nrr3G5CTO7pkGxtIwddsg6\nAulGlVoibSNpUon/V6/ViEBaycEHZx2BdLPoollHIJKOAdFzj5GpOkfSpOIlpjuSGdx4I0ycWHlb\naYKLLso6ApF0bA7cBXTw7QlJ61Q2iirkDVgiVjlvgLt7x/Xwpy7uW8iAAfnp3E1DIu1q66wDaKxE\nScXd9Z8srUH1KyItrd5uWkSaa/jwrCMQkTKUVKT1xa9Oxo0rvZ2IZE5JRdrL0ktnHYGIlKGkIiIi\nqWmppGJme5nZU2a2wMy6CtYdZ2YvmtlzZjYiqxhFRKS0anspbrQngT2B8+MLzWx9YG9gA2BVYLyZ\nrevu85sfooiIlNJSVyru/oy7P1dk1e7AP9z9E3d/GXgR2LS50YmISCUtlVTKWA2YGpufFi0TEZEW\n0vTiLzMbD3y2yKpfuPv1Kez/EOAQgIEDB9a7OxERqULTk4q7b1/Dy6YDa8TmV4+WFdv/aGA0QFdX\nV8f3UyYi0krapfjrBmBvM1vMzAYD6wAPZRyTiIgUaKmkYmZ7mNk0YDPgJjO7BcDdnwKuBJ4GbgYO\nV8uvXkT9fYm0jZZqUuzu44gNCFaw7iTgpOZGJCIi1WipKxUREWlvSioiIpIaJRUREUmNkoqIiKRG\nSUVan1p/ibQNJRUREUmNkoq0vpVXzjoCEUlISUVa34orZh2BiCSkpCIiIqlRUhERkdQoqYiISGqU\nVEREJDVKKiIikholFRERSY2SioiIpEZJRUREUqOkIiIiqVFSERGR1CipiIhIapRUREQkNUoqIiKS\nGiUVERFJjZKKiIikRklFRERSo6QiIiKpUVIREZHUKKmIiEhqlFRERCQ1SioiIpKavlkHIJLIuHHQ\np0/WUYhIBUoq0h6+/vWsIxCRBFqq+MvM9jKzp8xsgZl1xZYPMrM5ZjY5evwlyzhFRKS4VrtSeRLY\nEzi/yLop7j6kyfGIiEgVWiqpuPszAGaWdSgiIlKDlir+qmBwVPR1l5ltVWojMzvEzCaa2cRZs2Y1\nMz4RkV6v6VcqZjYe+GyRVb9w9+tLvGwGMNDd3zazocB1ZraBu88u3NDdRwOjAbq6ujytuEVEpLKm\nJxV3376G13wCfBJNP2JmU4B1gYkphyciInVoi+IvM+tvZn2i6bWAdYCXso1KREQKtVRSMbM9zGwa\nsBlwk5ndEq3aGnjczCYDVwP/4+7vZBWniIgUZ+6dW+1gZrOAV7OOI2Yl4K2sg6hTux9Du8cPOoZW\n0O7xQ/ljWNPd+9ey045OKq3GzCa6e1flLVtXux9Du8cPOoZW0O7xQ+OOoaWKv0REpL0pqYiISGqU\nVJprdNYBpKDdj6Hd4wcdQyto9/ihQcegOhUREUmNrlRERCQ1SiopMLM+Zvaomd0Yzfczs9vM7IXo\neYXYtseZ2Ytm9pyZjYgtH2pmT0Tr/s+a2Kummb0SvfdkM5vYbsdgZsub2dVm9qyZPWNmm7VZ/OvF\nhnWYbGazzexHbXYMR0XDVjxpZn83s8XbKf7ovY+M4n/KzH4ULWvpYzCzMWY208yejC1LLWYzW8zM\nroiWP2hmgyoG5e561PkAfgxcDtwYzf8eODaaPhY4LZpeH3gMWAwYDEwB+kTrHgK+Ahjwb2DnJsb/\nCrBSwbK2OQbgYuCgaHpRYPl2ir/gWPoAbwBrtssxAKsBLwNLRPNXAvu1S/zR+25IGHpjSUL3VeOB\ntVv9GAg3hm8CPBlbllrMwA+Av0TTewNXVIyp2f80nfYAVgduB75KPqk8BwyIpgcAz0XTxwHHxV57\nC6H3gAHAs7Hlo4Dzm3gMr9AzqbTFMQDLRSc0a8f4ixzPjsCEdjoGQlKZCvQjnJBvjI6jLeKP3msv\n4K+x+V8BP22HYwAG0T2ppBZzbptoui/hZkkrF4+Kv+r3R8KXb0Fs2SruPiOafgNYJZrO/fPlTIuW\nrRZNFy5vFgfGm9kjZnZItKxdjmEwMAsYa6EI8kIzW4r2ib/Q3sDfo+m2OAZ3nw78AXiN0KP4++5+\nK20Sf+RJYCszW9HMlgRGAmvQXseQk2bMC1/j7vOA94EVy725kkodzGxXYKa7P1JqGw8pvtWb2G3p\nYVTNnYHDzWzr+MoWP4a+hMv/89x9Y+AjwiX/Qi0e/0JmtiiwG3BV4bpWPoaozH53QoJfFVjKzL4b\n36aV44eFAwSeBtwK3AxMBuYXbNPSx1BMFjErqdRnC2A3M3sF+AfwVTP7G/CmmQ0AiJ5nRttPJ/z6\nyVk9WjY9mi5c3hTRL03cfSYwDtiU9jmGacA0d38wmr+akGTaJf64nYFJ7v5mNN8ux7A98LK7z3L3\nucC1wOa0T/wAuPtf3X2ou28NvAs8T5sdQyTNmBe+xsz6Eoqb3y735koqdXD349x9dXcfRCi2+I+7\nfxe4Adg32mxfIDf42A3A3lGLisGELvwfii5VZ5vZV6JWF9+PvaahzGwpM1smN00oC3+yXY7B3d8A\npprZetGi7YCn2yX+AqPIF33lYm2HY3gN+IqZLRm973bAM20UPwBmtnL0PBDYk9D4pq2OIRZbWjHH\n9/VNwjmu/JVPMyrBesMDGE6+on5FQuX9C4RWJP1i2/2C0OriOWKtQoAuwsl8CnA2FSrDUox7LUKL\nkMeApwgjcLbbMQwhDNj2OHAdsEI7xR+991KEX4DLxZa1zTEAvwGejd77UkILo7aJP3rvewg/SB4D\ntmuHvwHhR8gMYC7hqv3ANGMGFicUx75IaCG2VqWYdEe9iIikRsVfIiKSGiUVERFJjZKKiIikRklF\nRERSo6QiIiKpUVKRjmZmZ+V6nI3mbzGzC2PzZ5jZj1N+zw/T3F+0zyFmNjI2f4KZHZ3gdWZm/zGz\nZWPLvm5mbmafjy3rb2Y3px239D5KKtLpJhDu7sbMFgFWAjaIrd8cuC+DuKo1hNAfVbVGAo+5++zY\nslHAvdEzAO4+C5hhZlvUFaX0ekoq0unuI/TECiGZPAl8YGYrmNliwBeASWa2tJndbmaTonEldgcw\ns1PN7PDczuJXCGZ2jJk9bGaPm9lvir15sW3MbJCFcV8usDB2x61mtkS07svRtpPN7HQL43ssCvwW\n+Ha0/NvR7tc3szvN7CUzO6LE8e9D7I5uM1sa2JJwk9zeBdteF20vUjMlFelo7v46MC/qemNz4H7g\nQUKi6QKecPdPgY+BPdx9E2Bb4Iyoy4orgG/Fdvkt4Aoz25HQzcWmhKuIoVbQEWeFbdYBznH3DYD3\ngG9Ey8cCh3ro4HN+dAyfAr8mjGUxxN2viLb9PDAi2v/xZvaZIh/BFkC8w9PdgZvd/XngbTMbGls3\nEdiqxEcpkoiSivQG9xESSi6p3B+bnxBtY8DJZvY4oWuL1QhdiD8KrGxmq5rZRsC77j6V0EfajsCj\nwCTCCX6dgvctt83L7j45mn4EGGRmywPLuPv90fLLKxzXTe7+ibu/Reg0cJUi2/Rz9w9i86MInZ8S\nPY+KrZtJ6GVYpGZ9sw5ApAly9SpfJBR/TQV+AswmXBlAKPbpDwx197kWep5ePFp3FaEzvc8Srlwg\nJKFT3P38Mu9bdBsLQ7J+Els0H1iihuMq3Eex/+d5ZraIuy8ws36EweS+aGZOGGXSzewYD/01LQ7M\nqSEOkYV0pSK9wX3ArsA77j7f3d8hDDm8GflK+uUIY+PMNbNtCcP55lxBqH/4JvmxTm4BDojqKDCz\n1XK93MYk2WYhd3+PUN8zLFoUr/P4AFimmoOOPEfoNJQo/kvdfU13H+TuaxBGzcwVea1LSLoiNVNS\nkd7gCUKrrwcKlr0fFR0BXAZ0mdkThK6/n81t6O5PEU7o0z0aUc/DyIaXA/dHr7magpN+km2KOBC4\nwMwmE3oufj9afgehYj5eUZ/ETYQetCEUdY0rWH8N+SKwbaPtRWqmXopFWoiZLe3uH0bTxxLGGj+y\njv0NAC5x9x0SbHs3sLu7v1vr+4moTkWktexiZscR/jdfBfarZ2fuPiNqurxswb0q3ZhZf+BMJRSp\nl65UREQkNapTERGR1CipiIhIapRUREQkNUoqIiKSGiUVERFJjZKKiIik5v8B5bE3BSfujRkAAAAA\nSUVORK5CYII=\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAcQAAAElCAYAAAB6R5I4AAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAAMTQAADE0B0s6tTgAAIABJREFUeJzt3XncXOP9//HXlQ0hIoqI2oKonXAoURr1E7uSIJbYq7Zq\nCWpvK7RoNW35UlsVQQWhIfZ93y77vkcstQQhEiLL9fvjOuM+M/fM3DNnzsw5M/N+Ph7zmJlzzpzz\nOffMfT7nus51rss45xAREWl33dIOQEREJAuUEEVERFBCFBERAZQQRUREACVEERERQAlRREQEUEIU\nEREBlBBFREQAJUQRERFACVFERASAHmkHkJZjjjnGDRgwIO0wRESkRlddddX11toRta6nbRPigAED\nGD16dNphiIhIja666qp3k1iPqkxFRERQQhQREQGUEEVERAAlRBEREUAJUUREBFBCFBERAZQQRURE\nACVEERERQAlRREQa7U3gN8CstAPJ17Y91YiISEp+DrwMrA3sn3IsESohiohIY00Nn79JNYpOlBBF\nRERQQhQREQGUEEVERAAlRBEREUAJUUREBFBCFBGRRnNpB1CcEqKIiKTDpB1APiVEERERlBBFRCQt\nGas6VUKU9uacf4hI21NClPa2wgqw4YZpRyHSXjJ27TBHnXtLe5s82T9EpO2phCgiIoISooiINFpG\nL9srIYqISDoydi1RCVFERAQlRBEREaCJWpkGQXA2sAOwHDDYWvtsOH0J4HJgRWAWcKi19oHUAhUR\nkabUTCXE64CfAO8WTD8DeMxaOwjYD7gqCIKejQ5ORKSl3QEsDryXdiD10zQJ0Vr7gLX2/SKzdgXO\nD5d5EvgQ+GkjY5Mm8+mncPHFMG9e2pGINI9DgKnAFQmuM2OtTZumyrSYIAh+APS01n4UmTwZWLYR\n23/rLVhmGejVqxFbk8Tssgvcfz/065d2JCKSIU2dEKsRBMFoYHTu/eDBg2ta3zvvwEorwXbbwU03\n1RqdNNQLL/jnTz5JNw4RyZSmqTItxlr7GTAnCIIlI5OXB6YUWXastXbp3GPVVVetadu53r4mTapp\nNSIi7Uv3ISbuWuBggCAI1gd+CNyfakQiItJ0miYhBkFwQRAE7wNLA7cHQfBmOOtYYEgQBG8AlwKj\nrLWzUwpTRKQ15UpzGWsIk6SmuYZorT2oxPSPgWENDkdD6LUCfYkiEtE0JUSRxJjwVPerr9KNQ0Qy\nRQlR2tfxx6cdgYhkiBJiAq67Lu0IRESaSEavVighJmCvvdKOQESkzurRqEa3XYiIiJC5kqISYgK+\n/TbtCEREpFZKiAm66y646KK0o5AumYzV04hIJjTNfYhZU+wWti228M8HHtjYWEREmkpGz0lVQhQR\nka61QU81SogiIiIoIYpIs/ruu7QjkLgyWspUQozp1VfTjkBiU6Oa7JgGvBbjcwcdBPPNp+73Gqke\nSSxj/4pKiDH96lf57x98MJ04RJrassAqVH+wvfBC//zeewkHJF3KWBJLkhJiQvbdN+0IpGIa5SI7\npofPN6UahVRCjWpERBrghbQDEFFCTIwKHSIp0D9ec8vY16eEmJDJk9OOQEREaqGEmBCdqDYRtTIV\nkSKUEEWkeelMtHHUqEakTcybl3YEIu0nY5U1SogNdM01sMIKMH1618tKg739dtoRtLcWLnVI81BC\nbKCRI+Gdd+Chh9KORDpJ+7riU0/BBx+kG0OalBAlA2InRGNMH2PMNsaYXxpj9jLGrJVkYM3srrvK\nz9dlj5SlnfyKCQJYeum0o2g+7XwSIYmrOiEaY5YzxlwGvAUcBfwU2BG42hjzqjFm/4RjbDpbbAE3\n3JB2FCJtYOut046gfWTwPDJpcUqI44AJwFLOuc2dc3s650Y451YDtgIGGWN+VX4VrW/48NLzVELM\nIH0pjfdY2gEk4CpgM2Bu2oE0UAv/q/So9gPOuU3LzJsMHF9LQCLSJjaKvP46tShqs2f4PBlYMcU4\nmlXGkmvFJURjzPzGmF4F0wYkH1LrU2Ekg7J4XbGd/DntAJqQA2akHURMGT0GVpQQjTFHArcAk4wx\n/zTGLBDOurJukYmINIs0DvC/ARYCmrldUcbOQystIY5wzv3MOTcMuB64yRgzqI5xtTSVEFNWrDR4\n993w7beNj0UkrnPC55cbtL2MJa96qDQhdjfG9ABwzt0J7AucB6xcp7hEGuugg+CII9KOQppVmie5\njd52bnuzgW2AWxu8/TqqtFHN0cBiwEcAzrn3jTHbAnvUK7BWphJiymbOLD79wQcbG4dIEhp1PCnc\njsUnw1sbGEOdVVRCdM497Jz7qGDad865S+sSlUg9leo7T2cqklVvA/9MYbszge8KpiVRdZrR6tda\neqrZ1BjzhDHmc2PMV8aY6caYr5IMrtnNbad7k0SkfgLgUOC5Bm93QWDJBm8zRbX0ZXoRvrH0OsCq\nwCrhs4TGjEk7AqmKSoiSVV+Ez2ncr5nbdpKluoz+q9WSEL9yzl3nnJvinPsg90gsshZwyy3Fp+u4\n27w+/xwuvBDmzEk7EsmUdmxUk4SMVZ1W3VNNxARjzF7AeOdcYS1zQwVBMBmYBXwTTjrdWjs+vYg8\nJb4mU8EXtt9+cOON0KMH7L23fxZpmGIJRMeZxNRSQnwFf+vFN8aYucaYecaYNK+ajbTWrhM+Uk+G\nAF+VuKKqRNm8Xg7v+brtNujZEw45JN14pM1krERVs4wdC2tJiH8Dfg70AxYG+oTPEnrjjbQjkHq5\n9lr/fP756cYhGZGxA7vEU0uFzyfOuXsSi6R244IgAHgCOM5a+2nK8ZSkEqKIxJJmlWmrlU6LqCUh\n3hgO83QN8H2fV865NG692NRaOyUIgp7AacBl+D4UvhcEwWhgdO794MGDGxthhWbN8g02Flww7Uja\n0Pvvpx2BSNfmAQ+kuP0WPqGvpcr0NOBsfO81XwDT6Gig21DW2inh82zg78AmRZYZa61dOvdYddXG\n3iHyyScdr8uVEPv3h4UWqn887WjCBHjppTILzGjWoQOkbRjgUvwYjDmNTlCPA1sALXjXeewSonOu\nlmSamCAIFgR6WmunhZN2B55JMaQ8/frBK6/AgAoHyvryy/rG08523tk/t/AJrrQ6Q+eb8xv9g74t\nfG7Bwf9iJ0RjzPbAg865aeH7fsAQ59zNSQVXof7AhCAIuuN/Lm8Dezc4hpKmTYOJE/On6Rqi5NEP\novnpK4wnY9cla7mGeKpzbp3I+2nAqUBDE6K19m0gmxcEKzRzJrz4ImywQed5X3wBfftCt0yUx0Uk\nVY1IIN8BvYpMz1jyqofEDrPOOQd0T2p9reSaa/LfT54Mn30Gm2wCTzwBI0fCj38MTz+dv9wnn8Ci\ni8KeezYsVEmDSojNr5FfYT0T02PAfMDFKceRkloS4nRjzJDcG2PMxkCJYQTa2z0FN6ccfTSssgo8\n9JBPhpMm+elvv92xzMcfw8MP+9dXX92YOEVS9be0A2hSSSbjm8LncxNcZzGf1Xn9MdVSZfpb4AZj\nzKvh+0HATrWH1B6mTvXPpQoHS3bRw/zUqfDUU7DllsnGJeV9V49OClVC9EYDR6YdRBNq5p/PC2kH\nkK+WVqaPGmNWBTYKJz2Sa2AjlYseC8sdF50DE6miGDrU30Kw3Xa+Feubb9YtRImYPTvtCKStlaqm\nnAn0bmQgMXxF577MPk4jkNKqrjI1xpxrjNnCGNPdOfeFc+6W8KFkWEfduuX3jZq7n27SJHjrrXRi\nakemBa+btJxvgGXwA9S1mmK/v1Pw4xa+WmRePbddzf/Cf4G+wLjkwqmHONcQ7wH2Ad4wxlxhjBlh\njMn6uUlT6KrmTH2jpufVV30y/PDDOqxcVaYd5iWwjheB94FfJrCuSqXZqCbXGO+ROm+3cB+rSYg3\nhM8FDQyz1jCn6oTonJvgnBsFrIzvIu1nwPPGmBuNMfsbYxZLOshWFq0K7eq4mJv/v/+VXmbOHDjw\nQH99UTpUnHM+KD6k5znnJBeLlPHfGJ+ZNSvxMDLLUDr5JnEyUa/EXmq9zZ4Qc5xzc5xzdzrnDnPO\nrYTvym0QcG9i0bWB996r/GCdWy7XIKeYO++Eiy/2t3FIDEsv3fhtqoTY4RD8wHLVKLyvKQ1Z+Aob\nPXBvdJkvgNvLLJuLLWMJsFAi9yEaY/oCM51zxzvn1kxine1obgKjSeZGck9iXdLB5yzHsZzByryW\ndjit6xNgtSo/U5emvxllKJ1Ukighxm00tg2wFR3Vt1GfAFeEr1s1IRpjbjPGLGKMWQjfu94kY8yY\n5EJrP13dgJ8rSKhhRzo24AnO4HieoEiXQrVQCbH5Nep/stx2kvgZnRU+F7ujvFyjmsfC52KXcw6q\nNajGqaWE2D9sWboNMBHdhygtrjczAejbSt38P/00HHJIc1cpZOEMsR7nNP8rsd56lhBzKrmNq1hs\nxaY10ahqtSTEnuHzpsCdzrnZwJzaQ5JG+Pvf4frr044i+047Dc4Ne+0w9bpQlGYJccMN4fzz4a67\n0ouhKxdfDAcfXPnyhX/OS4C/JBlQAzwDLAUcUTC9XKOarFY0lDtfuZbipcqU1NJTzYvGmNuAVYDf\n6taL+ssdN2+9tfO8b7+F+eev/Nh6ZNgjyFVXwTPPwJ//nEyMrebkkzteb1Z6seaV62lgTobPZQ88\n0D+ff75/PrKgO5uuSogHhM/HJBpVvqSTUe5a3KXAP1KKIc76uirRFvuqRgP/ibGtOoh9Yz7+Z3Y+\nsJlzbibQDzg+4fikiN/+tvO0447zA+D+/OfVrWuPPeAvCZ09N3OtW6ZMmQKXXNLYbWbxOua773aO\n6/PPffVGVGFCzEANat3Uu1FNNYrFUfgzOh94oovPzEwsoprVcmP+C8DOwLrGmN7OuQ+cc7eV/6jU\n4q674Ic/LD7v7rs7BsBNw5w50KMH7J2ZkSiT0YPZ7MGVLMjXjasy3WQTOOCA9r6Z9MYbYfnl4Ywz\n8qdnMXHX6is6J7OkSme16OpG/EpOPA5JKJYG0Y35TeSkk0r3lFJNy/Ovv+48bbfd/LiMcc2Y4Z/H\nxeya6dNP/Yl/vfoKjXscPYxzuZJRnMXRneZtw80sUY/OGKdM8c+ff578uuvtu+/glFPg/RpbUtx/\nv38uvMew2D/A9CYeZGc2vkuzUvXx1ZR2G11CLKar/7OMl951Y36LqPSY8OijsPHGnaePH++vJ6Zl\nn338paF//zu9GDpxjhXxHcWuwYt5s1bgLW5mOx5hSLFPVr2dorJ8Xa+UcePgD3+AXXapbT25v8mz\nz+ZP32uv8MWWfH+F5vTTK1tnFjtm/zZ8foD8hBanZ5ekE2ILFsa7kuQAwU/oxvz0lOvOLWrIEHj+\n+eLzDjwQHnyw8m1OmOCrSd97r7Llp04tvWyun9ZPP+2YdsMN/tFo/9v/BB5beW/o1o3NuRvo3MK0\nH18AsCJvd/p8YtIYWuOjj2r7/Jdf+udKfxTV+v6HfhvwJ2BRmLp4ZZ+dGHl9B76Oq0yvT1WJ/jzW\nAkZU+LlogjugyPwvY8aQhDilvdn4fku/LTKvCdRyY/6yRR6Fg3tIipzreFRq003987PPdl1jd+ih\nviFNqaR12WXw6193vF98cVh22eLLFquuHT7cPxptwL9PZ8M3fN3vamE/YhsX9Jzskqz7KfUFNfJ6\nmXP+CxswAC6/PP56Ku2YN45XXimy3g9g9nP5k0ptOnpZYSTwBjAhseh8wt0f37qi0luaoj+jSyOv\nS5X2yjWqyYJ/AMOB35eYn+XYqa2E+BTwDvB6+HgHeM8Y85IxZp0kgpPa3HEHrL66Hzrqm28q/9wt\nt8DgwbDGGuWX6+rYt+++5TvFjn6u3CgSWWlHsXDkhvzEEqJz8PDDlS8/dy5ceWX+WGBJufFG/zxp\nUu3rqvVLe3RY5M3awFGw2mr5VQgAzN/xcirlSzXFmv8n9dt6CdgRSKrKP05cSSebOKNbvBw+l6iF\nKspWsWyd1ZIQ/4Uv5C+AH5pyP+AC4ATg/2oPTWr14Yf+pBr8ZZ1Kbbutf/7f//y1ycsvz6+9mzfP\nX3P8uIb2JLvsAossUnp+dMDjau7JLiWJy3HRatO8hFhL1eb48TAscvC/+ebyy192GYwaBQfVoT+s\nJEp3SfUa89hW4YvlgGfxfYqVaGINMAlYHH9Em1IqtsjrL8LnicUWjGH3mJ8r9eeKcw2xGbpGuR4o\nbNRXjyHVYqolIW7pnLvUefOcc5cD/885NxHfbkoy5M9/hsmTq/9c//6+wcsGG/gEedhh0L27b5Va\ni+uu84WcuXN9RySFBg3qeH3hhR2v//UvuL1cr/ol1HpprNC86L/Ot1VcMHn6ad/M99xzffH96YLe\nkLfbrvznc19iqQvB5Uya5HthKCXJhOgc3HRT8V4kqjI58rpX6cVuLfG6K2nfKJZkQjyesucMVYtz\nDbGSn87hMWJpkFp6qpnPGDPIOfcGgDFmEB31F7pFOwMKS1YDB1a/jlxV67PPwlJLFV+m2uPnZpEm\n5j0KfoEnnQQnnlj6s7/4Rf42Z8zwJdi994aePWHllWH33eHUU/PXnUS1a7RUmFdCnFdwwWfuXH/W\nUOjNN2G99fx9hrnWSy+/3Hm5SsQpiW2/vX8u9seIDsxZi2hC3GGH0tuL5W1gc/yt0AWi4yiWui54\nA7AqvgY260r9ydbE3+hWyicJxlCkNXqeuAnx2a4XSUstJcTjgEeNMXcbY+7Gj9d8fDj6xfhEopOa\nNGpUnCef9KXIUozJP9bed1/12xgwIL9BzphwXJVjj/WNe3bZxd++9+67/l7utdeGadPgoovgtdc6\n56xarUYkkc2b5+uPR4zw97T06NGxwfvu8xl6zpyOe/Mqbcp71lnwu991vJ8+veN647vv+rODJO9V\nzH1JEybE7ymnWCnz2GP98/Tpvj7+yScrXNnQItNKXJSOVrtFT8ejB+1rgHVI5rphJeso0YCsJvOA\nSrqdvRLf23T0skbuf6DSSx3Ra3sP4RsLdSUj1/tjc85V/QC6A2fia+23Dx+Lx1lXWo+//vWvrhb5\nbTj1iD6mTq3tb1TpZ+NuI25glzOq+LyDD3busMPyp33zjXOnndbx/qGHnLvnnvh/kL/9zbmePYvP\nv/Za5847r/IfrXPOvfWWc/vv3zFt4kTnRo7svN1iZsxwbs6c4vPOPtt/dvHF89c1caJzSyzhXy+2\nWBhPnMfLzrF5+WX6VLnOOLo750YmsO4ZBcuH/zvu/yLTPouxP73C1xs556xz7uTw/QXh8z9LxFNq\nnSsWmXZQmeW3KrO+dWL8nbqw3nrrjS0TTcWP+B+EJ5IIIK2HEmL9HgMHOnfnnfE/f/LJlS03dWq8\n9TfkjzBzZv771VePv645cypb7o9/dO6KK5w788zyP1rnnNtoo/zPTpxY5A9V5se/yirF551zjp+/\n2GLlYz3hBJf+USB8xBFn3bOdc1Mi7+c55z4qWP5Pub9jZNpmVe7Pv11HQix8DAqft3DO/S98fVEF\n+7VUkWktmBBrqTK9xRhzojFmgDFm4dyj1hKrNL933oEttoj/+VNPrWy5xbLcSeBhh+W/f+ml+Ouq\ntL73xBN9C9RcFWUpV17puyyqxpQp+Y2HXn21+HK5psdd1df/6U/Vbb+eXPg8D3gUPyRRucY2rsy8\nckbhq1FzfTkcBSxZsEyuuje6jXur3M5+ZebNiGwnt94Dga4uZRdrCXpBlXHlFLuGWMVtYfVUS0L8\nHXAq8AG+EfM0Ohozi7S3JPug61WmdWUpF14IW2/tW3oWGjWq87Riw6TkWqR+/jkst5y/MFvYlVrU\nK6/4ASShPvdJ1ks3fIuI7sAQYFdga/wRLWcucB3+CBf3qJlrWZE7l/hbkWWmh9uKm3RzSp2P5BJb\nYbuk1WvcXjHVnHNl5Ib92K1MnXOJdfsmIgnL3ad4222+kjKOddf1n80V2V9/3ffYkDN9OvTp47tr\nu/DCjBfZu3BmkWn96EhMY8LHqlWu901gJeDdyDRH6YT1Z+BmYKMqtxNHYYdE5UqW1bqN6m5pafaE\nCGCMGQD8yDl3nzGmB9DNOdegto0iUpHc6NFx/Pe/nccfzFm44ApJ9ObRVjEbXyoMWzWHPflVbhBw\nHhAZaJpDgVvKfOal8FFvhffzXtqAbZaSkYRYS1+mOwOP0fFnXJ38u4FEJAsWWAA23DDeZ3faqfJl\ncz20t5JFgUrvEinlUOCzyPspQIUDdNRVrdWySarkVpIGqKXa83hgXcLrhs655/D9LIlI1jz+eNoR\nNKevgS46D4rlyjqss5kV6WshDbUkxLnOuc8Kpqm6VEREqpOFwY2pLSFON8b0Jyx4G2M2B5pwiG8R\nEUlVRsZPrCUhHovvRncFY8xD+DZLRyUSlYiItI9/ph2AV8ttF9YYsxn+zh0DPOKcm9bFx0RERDKp\nptsunHNfUt1gK3URBMEg4DJgMeBLYF9rbSMaLouISItolZvrLwAutNaujL/F9tJ0wxERkWbT9Akx\nCIIlgAC4Ipw0AVgmCIKV0otKRESaTU1VphmxDPA/a+0cAGutC4JgCr4b3TdzCwVBMBoYnXs/ONoF\nlYiItL2KEqIxZi3n3PP1DqaerLVjgbG592PHjs1SPw0iIu2rZ9oBeJVWmd5jjHncGHOuMWZY2G9p\nVrwHDAiCoAdAEAQGXzqckmpUIiKlrJV2ABlTbafpdVJpQnzBOfdjfGOVTYH7jTFXG2N2r1tkFbLW\nfgI8jR9tDGAE8L619s3SnxIRSVGZUbQaagjFR/potGbs3Ns596Rz7iTn3Mb4vkz71yesqh0EHBQE\nwev4kc2SHMhERNpNtOeUccCcBNc9ifongH8AexVMKxxo+DLgYeC3dY6lEhlp3llp1ecZhROcc+8A\nJcaFaSxr7Ws0ZgQxEWlVDwJrAIuE748Cnqej7ikp25aZ93tgFaCWurfhwK/xHYiPi0xfCn+n9lRg\nJLB3ZN4TwAY1bLNWGUmIFYXhnCscOQsAY8xqyYYj7aqtG/2+9VZ919+vX33WO2IEvPhifdZd1jX1\nWe1P6EiGAGcBd0TefwVMjrnugypc7iRgN+DEmNsBuCp83pn8ujKDLzkCnFrwmfVr2F5UzFHGOCKh\n7deo1ryciRKiNL+BA5NZz7nnJrOeRPQs0XTurbdg/PiO9yusUJ/tz54N8+bB55/DBRd0TH8yxgB/\nP/qRX5e1HdO22QZWXx0uu6z2WKtSpL5xkwZstg9+gLvnYnx29QqXy9XZbRxjGznzRZ4viUw3wB74\nkSXqNZZzrtT5xy6WW7Dg/c/qEEsMFSVEY8xXxpg7jDF3hs93GGPuBNr5vF4S1K3CU7MeZSr5zzsP\nDj0Uhgzx71dcEf7wh5pDq9zkyXBi5NT+uOP884AB+cutsAKsu65/fcAB+fN23TWZWHbZxf+xTJg8\nfvnLjnlBUP36xo3z6xo82Md88cWwX1j82HtvWHZZ//rkk0uvIzEXA9PzJ1V6Te73CWw+zvW/gfiW\npRdWuHySwyHlvvrcz7Ce1y+H4UfIPaGL5dYueN9MVabA68CuzrktnHPDwscWZKetlGTIs8/6Qdqr\nYQysVqYCPleCPP74/Ol//7svuLz0Ehx8sJ+2bXiN5pBDYOTI6uKo1qToBaHlloPTToM//QleeAFO\nOQXefx8+/BAmTcr/4Eorwccfw4UFR0hTcLQ65ZTqgzr66K5LbSuu6J8POQQOPzx/3r33dk7MLrxt\nt1s3nwwPOCA/1pde8knzpJN8iXTVSDv66NnO7bfDbrv5ZWPpjq/HfLLz5GqsEnPzcfXClywPLLNM\ntHgxN8FtX4AfqbawVFboji7ml7JV5LWjo9r5B1WsY+GY205YpQlxCzqdkkGYFCVDZs1Kbl3/+le8\nz629dsfxtpgbb+w8zRh45hn49NPin4mWDGfP9rHdeCP85jcdyTR3fD7mGLjrLj9vlVV8wa1eDuQi\n+OMffRLMOf54WGMNH9APf+inbbYZ/PjHcPPNHcstsUTnonFhQjzySBg92idY6CiJFdpnH38W0rMn\n/OUvXZ+R5Eqt3bvDL37RMX3rrWHoUP+Hq8ZCC8GoUdCrl79mmTsTWW21jh/DmDEwbBj85z9+2Vhy\nRaedyWt58ifyD8z1FP3Kjqxg+V2AzYpMf6bgfbQVaNID5lZy43sSR/No3OVKooXdovROYNsJqLRR\nzRfOue/PWYwxWWioK0X06tX1MlsVHDhefx36F9xA8/vfV1/Kq4UxPvbFFvPvo+1Ahg+H+ef3r53z\nyXH//WH77Yuvq2dP2HzzjiS63HJw1VXFl63GNeyS934BZvIRA+CEEzoXXQv17g2PPeavu5VTmBD7\n9IG//tUn2NmzfbIrdNttvqT55Zfw9dcV7Amw6KL+uW/fjtIfwC23+Oe5BUUUV2XHTtHlC/cptuMi\nr78Aru54O5Dy4+4sRH4JrJaQop89pILlr6F4Qlqn4H3fyOskS4iNFP2ZlMouRZtoZkPcmttGnYtJ\nApZeOv/9mmt2VCuCLyRU2hDxkUfggQd8jVqlCfOkk2Ds2I73GxZpiRYtKDnna91yRo3yBSUonQS7\nsm25pu4VcgVH0W+pwxnD0KGl50WLycbAtdf6VkRbbunPJnr2LH9G9PjjMCXswOn88/0f9bclzm3n\nFRRRqi0xRuUSYrVJNX8l1HQH+TTgqch7h29peVINIdVTV9WbpfRJNIoOZWp88kS/4sLr/X/E1zMO\nSySiuoibEDPSr4BEPfCAfz7vvPzpL7+c/96Y/GOTc77wEVXq2LXkkrDJJr6R5KOP+mkLLNC5hLlL\nWJi69VY49VR/7J02zRdgFl/cH2/vv79j+Vwbk2KM8e03vvsONkjxXqloQvwJD9ZnIwce6G9lmDHD\nX2PsFETki9l5Z9+KqFIbbADLLONfDxjgz1IWXth/qQCbbtqxbK6EOHiw/7L69iXTujoidQ+XiS53\nEp1vP6jEUuHzdnSu+kvKMHyfYNXYH19wrodKj/jRv8c5BfPmx5fUC5fLkLgJMaO707qitU7RFvRR\nm4RNz3PHvJxil6mijRv79++41BW1yCKdp0XjWHtt+OormDkTPvoIXnut47a0k0+Gd9/Nr57t2xcW\nXLBjPZsIlgciAAAX1UlEQVRu6pPcHXfAEUXuQ7rvPn9JK7eOUncxpOFhflKfFRvjb2Xo3dtfYyy3\nXFL69/e3gtweqcvKlRC7d69tW0nGmYRcw61ospmOv8ewUovgb26fSO1HwlJVrt3ouqVmoe5U37io\nUjtVuFz07zEcX5Wdk7GfQjEqITaJiy/ueH1guZZqdF0zte66/rrcrFm+ILLQQp2vsfXq5WvizjrL\nJ7acYpe4clZe2R/Lc8uVav8R1bMnbLFF8dspfvpTf0krd/0wbfcxlLV4jrXTbFw9X3iTWe4aYFJW\nWCH/D51LiJXeD1OopurRBO0HRGoi2Bm4h44b1MGXWqqtavwB/uhZa+OXX9X4+ah63rpwOpU1zCn8\n2qPv5yuzXEbE/RNWUU8jSYhWSRY76V5++eLLFnr88Y7qzF69fEEEfAkxWmo8/HB/LDzqqPzElrUT\n/ka6kF/yAmvxfKebqBpou+38l3PfffXdTq7KNG5CXCsczmHzzWu7hvija/F9qHUh97s8B/hr+Hob\n/I3pmxYstxm++i4JtR7YczUzxW4/7WrdPYDf4XuVBihz2aFmlZY8y50g7JtAHHUW69funHvFGLOC\nMWZo+KhTVxut7ZJLul4mp6tjyRprdLzeYANfssuJJrENNiid1HLbGDbMX1qKyrWiz7UCbTZVJfJx\n43zx+Yor8u5jcVm4e7hHDzj77I6ieL3kEuF885VfrpThw30LrGKtYquxzaNEhjEtLff9/go/DPhU\n4KbaNl2RUv+Xd1f4+b74Kturu1qwiN2BU8LH/cAvyi9es1L/Q9F/i1IlxDPJzK0V5VT9H26MWdUY\n8wS+n/Qzw8fDxpgnjDF1/i9tLdU0EMm16CzVkUnhAX/48I7XvXv7TlNur7C5c7Hk+5//+GuFvZvg\nR12zRRf1xec996zsPpZWdNxxsOOOcNFF8T5vDGy0UW1/v8LbEqqRq9KstxXx1a2FeX/xKtaxEMWT\nTbFku2WRaT3xpeB672+phHh25HWphNgkNUtx/oSXAmc65wY4534cPgYAfwb+nWh0beTaa8vP797d\nN0DJdYF54on5vXEVJsTCpHb66b7kF5cxjb0vMVWFN2q2oyWWgBtugEEJdHp52mn+uZpu6c7G36he\nadE+rQPu/PgGOUcXTM/dxrRywtv7BR2tXBt9Ha7U3zh6S0ZhlWkuxgxUrlQiTpiLOOcmFE50zl1H\n/q2l0oXo/3pX92v37p3fyvK00/JbmyZxbW+nsCVZ7E5EWkXc62ZS3IgRvpHOqlUMi74x+SNP5FSz\njjQtja/GfKSGdeQK19HGLN2AXFe0WWyYUhhTroOBwn+pLMZOvIQ41RizlzHm+88aY7oZY/YBPksu\ntNYXTWLlapaWWQbW72J4lsJbJOK0X9huO38bxd57d72sSFWqPWPL/X5zLbr22cffGpLKcFMVKryZ\nflOq68+z0FDgN/ixCnOyXvVYeNzJlRjrdTtIwuIkxH3w7YU+N8a8Yox5Bfg8Ml1i6NEDHixxr/dv\nf1v6eLLHHv55xx3zp8dt9d6nXj1dpGyhhbpepqSZM9l56xmJxSJVOOQQf8/R2Wf7W0NKld6zkChe\nSHh93fED7BVeS83CvpZSqoRYmBBbpYTonHvTObc5fkStPcPHIOfcz5xzrycdYCsrTHKLRy7EX3pp\nZS06L7sMnn4afv7zRENrOTVVKS+wAP93SW+2UFf2jbNc+Nyrl78fqLDZc6EsJImExvQsK7qfWUwq\nlSbEjIp9scQ596lz7unwUWKMAolrn306Xpc7mPfo4XvX6qpRjdRmySU72oZIAzTp7T0NkYXkX0ph\no5p2SYjFGGNUQqxCV6WW3LW8OOO55k6oF6+m+beU1c6dEkiF/gPU88QpzRJiJb//wphy11ULb2fN\n6Al7mfHHizPGrFVmdotegUrOTjv51uyVOOssPxResX5Gu9K/v7/vcM01q/+sFKeEmGFZ+W52a8A2\ncvta76TyFpWPcpFTGNOt+J6DqrjjJk1VJ0TgWWAyxX+CtbSpagvdq6g6iI4vG0ct9x22rWJjU4lk\nSa7P93ocbY/BdzKwQvioVmGV6VrAZUWWiybOXYrMT0mchPgu8BPn3IeFM4wx79UeUuu7/nq4557O\nHVoPHAgrrdQx9p9ki0qIdbY9jelurZkZfEfbP8Anr6Tlbu+KO8xataXWo+ncy0+K4iTEG/HnDp0S\nInBzbeG0h5128o+33sqf3qsXvPFGOjFJ15QQ6+w6Ol9r6tIICMZA3zbqNbIffrDdehgBXA/8vyLz\nKvn9V1oDltH/paoTonPuN2XmHVxbOO0lNzbggnFHx5aGWjvFQS7aQqxuT6+HPX4C7dKNcr0TSTcq\nH/sw6gngcuDHFS6f0UY16qMqRUsu6atPC0e0l2yq5vqv1NGnussrc9bHD71VbUbJWEkxzmgXZc8B\njDELGGNWK7eMdNhpp8oG0hWR0GKL5Xc9FB0MtNWlmUCKbfvymOvKaAkxzjXEo4wx/YCrgMeBj/F9\nvv8I2AoYBhwJqNwjUqnDDy8/srPkW3hh+Ppr/7qw30JpjFOAvWpcR8ZKiHGuIe5qjFkfOAg4Ed+v\n+wzgeWACsLFzTh0/lqBjnhR19tldL9MObqTjtoJKtVNrp1bZ1RYqIeKcexJ4MuFYWt6YMfDrX6cd\nhUiGbZ92AFJSYTJOIjlnLMHHSogSz8knpx2BdEk9eEuWZSyBtBq1MhWJ+v3vK150xx3hoYfqGItI\nq2qlKlORlvT111XdW1Fpn7QiiclSCbEFq0yTHu0i1q21IpmgHhIkq9YLn9NslJdk8soNAzF/gutM\nQOyEaIy5xRizaOT9isAjiUTVQubMga++gmnT0o5ERJrW7cAkYN20A4moJUFeDhwAHJFQLAmppcr0\nHuBJY8woYBngLGB0IlFVKAiCPwCHAR+Ek16y1u7ZyBi60r079NGgWCJSix8A26YcwxHAqQmta3ng\n4oTWlaDYCdE5d5Yx5kngXuAzYBPn3NuJRVa5K621DT/P2H57uEk987ctDa0lbecYYBPgEPxYiS2o\nlirT5fEDd1yGHx/xRGNMxmqE62fAgLQjkDTsuScMGQK33ZZ2JCIN1gfYgsw1hElSLVWmDwJHO+fG\nG2O6A2fi+zxfK5HIKrdrEAQ/A6YCp1pr723w9qWNXHFF2hGISL3UkhA3d869DuCcmwscbYxJtJY7\nCIJHgUElZg8Gzgf+aK2dHQTBxsANQRCsb619t8i6RhO5xjl48OCaYnMZvY9GyltqKYqP5DlmTKND\nkVqccQbsvXfaUbSnFj721ZIQvzXGFI7T8EItwRSy1m5UxbIPB0HwDBAAnRKitXYsMDb3fuzYsTV9\nreUS4plnwrHH1rJ2qYevv/aDMBcdd2/dLDXfky7ttZcSYtpasOq0lvsQnwJs+PwS8E74vmGCIFg6\n8noQsA4JJ+U4jjkm7QikmAUXhJ49045CioozKK1IwmppZbp49L0xZjjQ6DHF/xgEwXrAHGAucJi1\n9vVGbFhVpiIJeRdYKu0gpGItfOxLrOs259z1xpgTgMo7g6yRtXafRm1LRBK2MfAwoAGym1MLVpnG\nTojGmIUjb7sDPwYWLrG4iEi+B4Hv0g5CpEMtJcRp+MKzwVdXvgFotD8RqYwB5qvh89Om+b4RpbFU\nZdqZc66th47SNcQmNnQo3Hdf2lFIrfr2TTuC9qYq005VpZ04576KH45IAyysmn0R6SxOCTFaVVrI\n4a8ntrxyJURj4N57YeDAxsUjItIQLVw7VnVCbPeq0koNHZp2BFKSacG6HpFGa8F/o6qTmzHmwsjr\nnycbTvPQNUQRaUu5YpQSIgDrR1437J5DkboaVKrLXBHJcz2wA3BQ2oEkL841xGjZqAXPESqjEmIL\n2WMPWHnltKMQaQ5rAhPTDqI+4iTEBYwxa+KT4fyR1wA4555PKrgsU0JsIWr9JCLETIjAjZH30dcO\nWKGmiERERFIQp5Xp8nWIo+mohCgi0lp0C4W0H912ISJFKCHGpBKiiEhrUUIUERFBCTG21VfvPG3/\n/eEr9eQqItKUlBBjOuoouOGG/GlLLgl9+qQTj1RB1xBFpAglxJh69oQdd8yfdtxx6cQiIiK1U0JM\nyBJLqHTYtFRiFBGUEEXUZFhEACVEERERQAlRRFWmIuX0TTuAxonTl6lIa1GVqUhx04D50g6icZQQ\nRUSkuDYqHYKqTKUdFVaRqspURFBCFFGVqYgASogiIiKAEqK0I1WRikgRSogiSpAighKiiK4higig\nhCgiIgIoISZm553TjkBiU5WpiKCEmJh//CPtCCQ2VZmKCEqIiemhPn9ERJqaEqKIqkxFhCboyzQI\ngm2BMcAawD+ttUcUzD8J2C98e7W19sQGhyjNpjABqspURGiOEuIbwP7AXwpnBEGwKbA7sBawGrBl\nmEBFRESqkvmEaK193Vr7HDCnyOyRwDhr7Qxr7SzgEnyCFKmcqkxFhCaoMu3CssBDkfeTgd0aGcCw\nYbDwwo3cotRMCVBEikg9IQZB8CgwqMTswdba9xLazmhg9PcrHjw4idVy++2JrEZERFKWekK01m5U\nw8enAMtF3i8fTiu2nbHA2Nz7sWPHqiWFiIh8L/WEWKNrgXODIDgHf41xf+APqUYkIiJNKfONaoIg\n2DwIgvfx1Z0HBEHwfhAEOwBYa+8DxgMvAK8Ad1prJ6UWrDSnVVZJOwIRyYDMlxCttXcDS5eZPwZ/\nn6JIPLurYbKINEEJUaTuuunfQESUEEVERAAlRBEREUAJUdqRbswXkSKUEKX9KCGKSBFKiCIiIigh\nioiIAEqIIiIigBKiiIgIoIQo7WjIkLQjEJEMUkKU9nPYYWlHICIZpIQo7UddtYlIEToyiIiIoIQo\nIiICKCFKOzIGrE07ChHJmMyPhyhSF+utBxMnwpdfph2JiGSEEqK0rx12SDsCEckQVZmKiIighCgi\nIgIoIYqIiABKiCIiIoASooiICKCEKCIiAighioiIAEqIIiIigBKiiIgIAMY5l3YMqQiCYALwbtpx\ndGFd4Om0g6gD7Vdz0X41l3bcr+WstSNq3UDbJsRmEATB+9bapdOOI2nar+ai/Wou2q/4VGUqIiKC\nEqKIiAighJh1Y9MOoE60X81F+9VctF8x6RqiiIgIKiGKiIgASogiIiIA9Eg7gHYTBMF+wCXATtba\n/wZBsARwObAiMAs41Fr7QLhsb+BfwPrAPOAEa+114bxuwD+AbQAH/N1a+38p7M/kMO5vwkmnW2vH\nt8B+zQf8FdgS+BZ4zlo7qpn3KwiCHwB3Ryb1BlYAlsAfC5pyv8I4tgFOw5/k9wD+Yq29rJm/rzCO\nrfD71QuYCRxkrX2u2fYrCIKzgR2A5YDB1tpnw+l12Y8gCE4C9gvfXm2tPbGSOFVCbKAgCJYHDgQe\ni0w+A3jMWjsI/wVeFQRBz3De0cAsa+1K+APzeeFBDWAUsBqwMrABcEwQBKvXfy+KGmmtXSd8jA+n\nNft+nYH/R1vZWrtmGHNuelPul7X2s8j3tA5wIXCrtfZzmni/giAwwBXAvuF+bQdcEARBH5p7v/oB\nVwL7WGvXAo4J30Pz7dd1wE/o3BlK4vsRBMGmwO7AWuEyWwZBsG0lQSohNkh4RnMxcDj+TChnV+B8\nAGvtk8CHwE/DeSMj894B7gN2isy7yFo7Nzygjcf/CLKiafcrCIIFgQOAE621Lozzo3B20+5XEQfg\nz8Ch+ffLAYuErxcGPsP/nzXzfq0IfGatfSmM8UFg2SAI1qXJ9sta+4C19v0is+qxHyOBcdbaGdba\nWfgauYr2UVWmjTMaeNha+1QQBMD3VVg9IwdbgMnAsuHrZck/o+pq3oZJB12hceE+PQEch6/eaOb9\nWhH4HDghCIL/h68O/gPwLM29X98LgmAI0A+Y1Oy/Q2utC4JgJHB9EAQz8Ps1HOhDE+8X8AbwgyAI\nhlhrHwmCYAf8Pg2kufcLqOvxb1ngoYJ5u1USk0qIDRAEwRrACPy1gFazaViluC4wFbgs5XiS0AN/\nreNla20A/Bp/BtpKJ5AHAJdba+ekHUitgiDoAZwEDLfWLgdsDoyjyb8va+2XwM7A6UEQPAUMA14G\nFko1sBamhNgYmwDLA2+EjVA2xF+/2RWYEwTBkpFllwemhK+n4A/M1c5rGGvtlPB5NvB3YBNr7Wc0\n935NwZdyrwSw1j4DvAOsSXPvFwBBECyE/+1dAv7aIs29X+sAS+UaY4RVb+/jryE1835hrb3XWvtT\na+16wFHAUsDDNPl+QV1/d7H3UQmxAay1/7TWDrDWLm+tXR7fqOaX1tp/AtcCBwMEQbA+8EPg/vCj\n0XkDgaHAfyPzDgyCoHsQBIvi681zDVoaIgiCBYMgWCQyaXfgmUh8Tblf1tqp+NaYW0ZiHAi8QhPv\nV8RIfKvZVyPTmnm/3gMGBEGwahjjSvhq79do7v0iCIIBkbcnA/dYa9+kyfcroh77cS2wV3h8mg/Y\nH7i6kmCaukqhRRyLvwb3BvAdMCosbQH8BbgkCIK3gLnAr8KDNfgqofXx1xkcMNZa+0JjQ6c/MCEI\ngu6AAd4G9g7nNfN+gf9H/FcQBGfiS4sHWWs/CIKg2fcLfHXpRQXTmna/rLUfB0HwS+CaIAjm4U/0\nf2WtndIC39eYIAg2wR+rH8V/d9Bk31cQBBcA2wJLArcHQTA9bD2a+H5Ya+8LgmA8kNuv8dbaSZXE\nqa7bREREUJWpiIgIoIQoIiICKCGKiIgASogiIiKAEqKIiAighChSNWPM740xF0fe/8QY44wxQyPT\nzjfGnFqn7V9qjDmiHusO17+OMWa3gmnOGLNIqc8ULDvAGPOYMaZbZFofY8zXxph/FSy7ljHm1mQi\nF6mNEqJI9e7F3yScsxnweJFp9zQupEStQ4V9P5ZwMnCuc25eZNpI4ClguDHm+67HnHPPA7OMMT+r\nYXsiiVBCFKneY8BSxpilw/dDgTHhM8aYAfgOhh8N319pjLHGmOeNMTcbY5YMp19kjMkNK4UxZqAx\n5iNjTM/wcYYx5gljzLPGmGuMMf0KAym3XFiSvMAYc7cx5nVjzPXGmF7hvD7GmPHGmFeNMQ+Gy11q\njFki3JfNwvWdH9ncoeF23jHG7FcYS7je+fHJb0LBrAOAM4EHwvlR/wEOKvP3FmkIJUSRKjnnvgMe\nwSeN+YCBzrlbgKXDhLAZ8Khz7tvwI0c45wLn3FrAg/iRMwD+DewbWfW+wJXOudn4se9mOOc2cM6t\ng+91o1jn8F0ttw6wPbAqvmehEeH03+FH8VgVP8jqkHDfPgnn3eucW8c5d3BkXbOccxsAWwNnG2OK\n9XS1PvCOc25mboIxZjVgGeB2/HBTBxR85lF8h9wiqVLXbSLx5KpN38UPewW+5LhROP3eyLJ7GGP2\nAuYPH1MBnHOPGGN6GGPWByy+27vtw8/sCPQ1xuQSWC/8MDaFulruhlxyMsY8ge/jE3wCOtL5rqqm\nG2PGAyt1sc9XhnG/aoyZg++Gq3CMu6WBjwumHQBc7pyba4y5BbjAGLOqc+6VcP5HwA+MMfNHTiJE\nGk4JUSSee/EH+in4gUvBd0q8WfjYF3yDG/zwURs55z4xxuyAr5LM+Td+pPCFgKnOuRfD6QY43Dl3\nRxdxdLVcNMHMpfT/fCV9OFayrpn4pO+DM6YnsBcw2xizRzi5N/5vl6sunj9c33cVxCBSN6oyFYnn\nSWAJYE/yE+JuwAA6So39gOnAZ+H1u8JrZeOAXfCdiV8Smf5f4EhjTG8AY0xvY8zqReKodLlC9wD7\nGC83HFTOV0DfCtZRzPPAjyLvdwDeds790Dm3vHNuefzwZ3uFyRJ8te2LBY1wRBpOCVEkhvA630NA\nH+fcq+G01/Ejmj8Uzge4DT8M0Wv464fPFqznQ3zy3AHfuCTnTHzSfdwY8zy+OnadIqFUulyhMWGs\nr4QxPgdMC+fdDcwXNgI6v8Tni3LOvQN8HEnKBxBWtUaWeQX4gI7q4a2A66rZjkg9aLQLkTYUls66\nO+e+NcYsiG/wco5zruax8YwxuwBDnXOHVbBsL/z1058556Z2tbxIPekaokh76gfcaozpjr+GNxG4\nJokVO+euNcb0N8Z0q6AadCBwnJKhZIFKiCIiIugaooiICKCEKCIiAighioiIAEqIIiIigBKiiIgI\noIQoIiICKCGKiIgA8P8B2ZcjAZvzxp4AAAAASUVORK5CYII=\n",
       "text/plain": [
-       "<matplotlib.figure.Figure at 0x116eedd30>"
+       "<matplotlib.figure.Figure at 0x11336b2b0>"
       ]
      },
      "metadata": {},
@@ -975,12 +1063,21 @@
     "ax.set_xlabel('Wavelength (A)')\n",
     "ax.set_ylabel('Flux ($10^{-17}$ erg/s/cm$^2$)')"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python [default]",
    "language": "python",
    "name": "python3"
   },
@@ -994,7 +1091,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.1"
+   "version": "3.5.2"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This PR makes a few small changes to the simulating spectra tutorial to make it compatible with the recently merged desihub/desisim#250 refactor of newexp.

* desisim.obs.new_exposure() return values changed.
* simspec files METADATA HDU changed name to TRUTH (I'm not sure if that was a good idea, but it did...)

I'd appreciate a separate cross check from @moustakas, @akremin, @geordie666, or others that these instructions work (as a post-facto test of desihub/desisim#250...)