### PR TITLE
Add a version of the DESI spectra tutorial that works for an SV-like data model

### DIFF
--- a/Intro_to_DESI_SV_spectra.ipynb
+++ b/Intro_to_DESI_SV_spectra.ipynb
@@ -1,0 +1,885 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Introduction to DESI SV Spectra\n",
+    "\n",
+    "The goal of this notebook is to demonstrate how to read in and manipulate DESI SV spectra using on-sky data. Specifically, we will use the February/March 2020 mini-SV-2 runs taken as part of DESI _commissioning_.\n",
+    "\n",
+    "If you identify any errors or have requests for additional functionality please create a new issue at https://github.com/desihub/tutorials/issues or send a note to desi-data@desi.lbl.gov.\n",
+    "\n",
+    "Note that this tutorial specifically deals with on-sky data from SV (or, currently, mini-SV). To learn how to work with Main Survey data look at the _Introduction to DESI Spectra_ tutorial instead. (e.g. https://github.com/desihub/tutorials/blob/master/Intro_to_DESI_spectra.ipynb).\n",
+    "\n",
+    "Last updated March 2020 using DESI software release 19.12."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Getting started\n",
+    "\n",
+    "### Using NERSC\n",
+    "\n",
+    "The easiest way to get started is to use the jupyter server at NERSC so that you don't need to\n",
+    "install any code or download any data locally.\n",
+    "\n",
+    "If you need a NERSC account, see https://desi.lbl.gov/trac/wiki/Computing/AccessNersc\n",
+    "\n",
+    "Then do the one-time jupyter configuration described at https://desi.lbl.gov/trac/wiki/Computing/JupyterAtNERSC\n",
+    "\n",
+    "From a NERSC command line, checkout a copy of the tutorial code, *e.g.* from cori.nersc.gov\n",
+    "```console\n",
+    "mkdir -p $HOME/desi/\n",
+    "cd $HOME/desi/\n",
+    "git clone https://github.com/desihub/tutorials\n",
+    "```\n",
+    "And then go to https://jupyter.nersc.gov, login, navigate to where you checked out this package (*e.g.* `$HOME/desi/tutorials`), and double-click on `Intro_to_DESI_spectra.ipynb`.\n",
+    "\n",
+    "This tutorial has been tested using the \"DESI 19.12\" kernel installed at NERSC.  To get an equivalent environment from a cori command line:\n",
+    "```console\n",
+    "source /global/common/software/desi/desi_environment.sh 19.12\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Import required modules"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import numpy as np\n",
+    "import healpy as hp\n",
+    "from glob import glob\n",
+    "import fitsio\n",
+    "from collections import defaultdict\n",
+    "\n",
+    "# ADM Note that we use the commissioning targeting mask, as we're working with mini-SV data from commissioning.\n",
+    "from desitarget.cmx.cmx_targetmask import cmx_mask  \n",
+    "import desispec.io\n",
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "%pylab inline"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If you are running locally and any of these fail, \n",
+    "you should go back through the [installation instructions](https://desi.lbl.gov/trac/wiki/Pipeline/GettingStarted/Laptop) and/or email `desi-data@desi.lbl.gov` if you get stuck.\n",
+    "If you are running from jupyter.nersc.gov and have problems, double check that your kernel is \"DESI 19.12\"."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Environment variables and data\n",
+    "\n",
+    "DESI uses environment variables to define the base directories for where to find data.  The below paths are for NERSC, but if you are running locally or want to access a different dataset, change these as needed to wherever your dataset is.\n",
+    "\n",
+    "Spectro production runs are grouped under `$DESI_SPECTRO_REDUX`, with `$SPECPROD` indicating which run to use, such that the data are under `$DESI_SPECTRO_REDUX/$SPECPROD`.  *e.g.* during operations, official productions will be in `$DESI_SPECTRO_REDUX=/global/cfs/cdirs/desi/spectro/redux` and `$SPECPROD` would be the name for individual data assemblies, *e.g.* `$SPECPROD=DA1`.  In this case, we'll use `$SPECPROD=daily`, which corresponds to the daily reductions for mini-SV-2."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%set_env DESI_SPECTRO_REDUX=/global/cfs/cdirs/desi/spectro/redux\n",
+    "%set_env SPECPROD=daily"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`desispec.io.specprod_root` can handle the environment variable path wrangling for you:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "reduxdir = desispec.io.specprod_root()\n",
+    "print(reduxdir)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#- Do check that these are set correctly before proceeding\n",
+    "def check_env():\n",
+    "    for env in ('DESI_SPECTRO_REDUX', 'SPECPROD'):\n",
+    "        if env in os.environ:\n",
+    "            print('${}={}'.format(env, os.getenv(env)))\n",
+    "        else:\n",
+    "            print('Required environment variable {} not set!'.format(env))\n",
+    "\n",
+    "    reduxdir = desispec.io.specprod_root()\n",
+    "    if not os.path.exists(reduxdir):\n",
+    "        print(\"ERROR: {} doesn't exist; check $DESI_SPECTRO_REDUX/$SPECPROD\".format(reduxdir))\n",
+    "    else:\n",
+    "        print('OK: {} exists'.format(reduxdir))\n",
+    "\n",
+    "check_env()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Data Model for the spectra"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Directory structure\n",
+    "\n",
+    "Spectra from individual exposures are in the `exposures` directory.  But since SV will focus on targeting individual _tiles_, the relevant directory and file structure is: \n",
+    "\n",
+    "```\n",
+    "$DESI_SPECTRO_REDUX/$SPECPROD/tiles/$TILE/$DATE/*-$SPECTROGRAPH-$TILE-$DATE.fits\n",
+    "```\n",
+    "\n",
+    "where:\n",
+    "\n",
+    "* `$TILE` is the number of the relevant SV (or mini-SV) tile. For example, for mini-SV-2, see the list of tiles on the mini-SV-2 [wiki page](https://desi.lbl.gov/trac/wiki/TargetSelectionWG/miniSV2#Fieldcenters).\n",
+    "* `$DATE` is the date expressed as YYYYMMDD, for example 20200229 for year=2020, month=february, day=29.\n",
+    "* `$SPECTROGRAPH` corresponds to the DESI spectrograph used to observe the targets (0-9).\n",
+    "\n",
+    "The files we will focus on for this tutorial correspond to `$TILE=70003` and `$DATE=20200226` and `$SPECTROGRAPH=0`. For example:\n",
+    "\n",
+    "```\n",
+    "$DESI_SPECTRO_REDUX/$SPECPROD/tiles/70003/20200226/coadd-0-70003-20200226.fits\n",
+    "$DESI_SPECTRO_REDUX/$SPECPROD/tiles/70003/20200226/zbest-0-70003-20200226.fits\n",
+    "```\n",
+    "where the first file contains the (coadded) spectra and the second file contains information on the best-fit redshifts from the [redrock](https://github.com/desihub/redrock) code.\n",
+    "\n",
+    "Let's poke around in these directories."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "basedir = os.path.join(os.getenv(\"DESI_SPECTRO_REDUX\"), os.getenv(\"SPECPROD\"), \"tiles\")\n",
+    "subdir = sorted(os.listdir(basedir))\n",
+    "print(basedir)\n",
+    "print(subdir)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "basedir = os.path.join(basedir, subdir[0])\n",
+    "subdir = sorted(os.listdir(basedir))\n",
+    "print(basedir)\n",
+    "print(subdir)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "basedir = os.path.join(basedir, subdir[2])\n",
+    "coaddfiles = glob(os.path.join(basedir, \"*coadd*\"))\n",
+    "zbestfiles = glob(os.path.join(basedir, \"*zbest*\"))\n",
+    "print(basedir)\n",
+    "print(coaddfiles)\n",
+    "print(zbestfiles)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### spectra file format"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "What about the Data Model for the coadded spectra themselves?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tile, date, spectrograph = \"70003\", \"20200226\", \"0\"\n",
+    "dirname = os.path.join(os.getenv(\"DESI_SPECTRO_REDUX\"), os.getenv(\"SPECPROD\"), \"tiles\", tile, date)\n",
+    "filename = \"coadd-{}-{}-{}.fits\".format(spectrograph, tile, date)\n",
+    "specfilename = os.path.join(dirname, filename)\n",
+    "DM = fitsio.FITS(specfilename)\n",
+    "DM"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "HDU 0 is blank.  The others should be used by name, not by number since the order could vary.\n",
+    "\n",
+    "`FIBERMAP` stores the mapping of the imaging information used to target and place a fiber on the source.\n",
+    "\n",
+    "The other HDUs contain the wavelength arrays, flux, inverse variance (ivar), mask (0 is good), and spectral resolution data coadded across each of the \"B\", \"R\", and \"Z\" cameras.\n",
+    "\n",
+    "Let's start by looking at the fibermap."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fm = fitsio.read(specfilename, 'FIBERMAP')\n",
+    "fm.dtype.descr"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`TARGETID` is the unique mapping from target information to a fiber. So, if you wanted to look up full imaging information for a spectrum, you can map back to target files using `TARGETID`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As we are only looking at a single spectrograph this should correspond to a single petal in the DESI focal plane. I wonder if that's true?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.plot(fm[\"TARGET_RA\"],fm[\"TARGET_DEC\"],'b.')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This certainly looks like one petal to me.  Let's repeat, color coding by spectrograph number."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ADM as of mini-SV-2 we only have spectrographs 0, 3, 6, 7, 9.\n",
+    "for spectrograph in \"0\", \"3\", \"6\", \"7\", \"9\":\n",
+    "    filename = \"coadd-{}-{}-{}.fits\".format(spectrograph, tile, date)\n",
+    "    specfilename = os.path.join(dirname, filename)\n",
+    "    DM = fitsio.FITS(specfilename)\n",
+    "    fm = fitsio.read(specfilename, 'FIBERMAP')\n",
+    "    plt.plot(fm[\"TARGET_RA\"],fm[\"TARGET_DEC\"], '.')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that in addition to having multiple tiles, we also have multiple exposures of the same tile resulting in multiple spectra of the same targets."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "DM"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The remaining extensions store the wavelength, flux, inverse variance on the flux, mask and resolution matrix coadded for the B, R and Z arms of the spectrograph. Let's check that the full wavelength coverage across all 3 arms of each of the DESI spectrographs is the same:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for spectrograph in \"9\", \"7\", \"6\", \"3\", \"0\":\n",
+    "    filename = \"coadd-{}-{}-{}.fits\".format(spectrograph, tile, date)\n",
+    "    specfilename = os.path.join(dirname, filename)\n",
+    "    wave = fitsio.read(specfilename, 'BRZ_WAVELENGTH')\n",
+    "    print(\"wavelength coverage of spectrograph {}: {:.1f} to {:.1f} Angstroms\".format(spectrograph, np.min(wave), np.max(wave)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Reading in and Displaying spectra"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now that we understand the Data Model, let's plot some spectra. To start, let's use the file we've already been manipulating (for spectrograph 0) and read in the flux to go with the wavelengths we already have."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "flux = fitsio.read(specfilename,'BRZ_FLUX')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that the wavelength arrays are 1-D (every spectrum in the spectral file is mapped to the same binning in wavelength) but the flux array (and flux_ivar, mask etc. arrays) are 2-D, because they contain multiple spectra:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(wave.shape)\n",
+    "print(flux.shape)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's plot one of the spectra from this file:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "spectrum = 23\n",
+    "# ADM make the figure 20-by-5 in size.\n",
+    "plt.figure(figsize=(20, 5))\n",
+    "# ADM some reasonable plot limits.\n",
+    "xmin, xmax, ymin, ymax = np.min(wave), np.max(wave), np.min(flux[spectrum][0:100]), np.max(flux[spectrum][0:100])\n",
+    "plt.axis([xmin, xmax, ymin, ymax])\n",
+    "plt.plot(wave, flux[spectrum], 'b-', alpha=0.5)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## A DESI-specific spectrum reader\n",
+    "\n",
+    "Note that, for illustrative purposes, we discussed the Data Model in detail and read in the required files individually from that Data Model. But, the DESI data team has also developed standalone functions in `desispec.io` to facilitate reading in the plethora of information in the spectral files. For example:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "specobj = desispec.io.read_spectra(specfilename)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The wavelengths and flux in each band are then available as dictionaries in the `wave` and `flux` attributes:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "specobj.wave"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "specobj.flux"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "So, to plot the (zeroth-indexed) 24th spectrum:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "spectrum = 23\n",
+    "plt.figure(figsize=(20, 5))\n",
+    "plt.axis([xmin, xmax, ymin, ymax])\n",
+    "plt.plot(specobj.wave[\"brz\"], specobj.flux[\"brz\"][spectrum], 'b-', alpha=0.5)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "which should look very similar to one of the first plots we made earlier in the tutorial. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The fibermap information is available as a table in the `fibermap` attribute:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "specobj.fibermap"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "specobj.target_ids()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "There are also functions for getting the number of spectra and selecting a subset of spectra.  All of the information that could be read in from the different extensions of the spectral file can be retrieved from the `specobj` object. Here's what's available:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dir(specobj)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Target classes"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "What about if we only want to plot spectra of certain target classes? For mini-SV-2 (which is part of DESI _commissioning_) the targeting information is stored in the `CMX_TARGET` entries of the fibermap array:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "specobj.fibermap[\"CMX_TARGET\"].info"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "and which target corresponds to which targeting bit is stored in the commisioning (cmx) mask (we imported this near the beginning of the notebook)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cmx_mask"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's find the indexes of all standard stars in the spectral file:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "stds = np.where(specobj.fibermap[\"CMX_TARGET\"] & cmx_mask.mask(\"STD_FAINT|STD_BRIGHT|SV0_STD_FAINT|SV0_STD_BRIGHT\"))[0]\n",
+    "print(stds)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Where were these located on the original plate-fiber mapping?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fm = specobj.fibermap   #- shorthand\n",
+    "plt.plot(fm[\"TARGET_RA\"],fm[\"TARGET_DEC\"],'b.', alpha=0.1)\n",
+    "plt.plot(fm[\"TARGET_RA\"][stds],fm[\"TARGET_DEC\"][stds],'kx')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's take a look at the spectra of the first 9 of these standard stars."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print()\n",
+    "figure(figsize=(12, 9))\n",
+    "for panel, std in enumerate(stds[:9]):\n",
+    "    subplot(3, 3, panel+1)\n",
+    "    plt.plot(specobj.wave['brz'], specobj.flux[\"brz\"][std], 'b-', alpha=0.5)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "These seem star-like. Let's zoom in on some of the Balmer series for the zeroth standard:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Balmer = [4102, 4341, 4861]\n",
+    "halfwindow = 50\n",
+    "figure(figsize=(4*len(Balmer), 3))\n",
+    "for i in range(len(Balmer)):\n",
+    "    subplot(1, len(Balmer), i+1)\n",
+    "    plt.axis([Balmer[i]-halfwindow, Balmer[i]+halfwindow, 0, np.max(flux[stds[0]])])\n",
+    "    plt.plot(wave, flux[stds[0]])\n",
+    "    # plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Redshifts"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The directory from which we took these spectra also contains information on the best-fit redshifts for the spectra from the [redrock](https://github.com/desihub/redrock) code."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zfilename = specfilename.replace('coadd', 'zbest')\n",
+    "zs = fitsio.read(zfilename)\n",
+    "zs.dtype.descr"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As a sanity check, let's ensure that there are the same number of redshifts, targets, and spectra in the files. This may not be so in the DESI _Main Survey_, where there might be repeat observations."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(zs.shape[0], 'redshifts')\n",
+    "print(specobj.num_targets(), 'targets')\n",
+    "print(specobj.num_spectra(), 'spectra')\n",
+    "print(specobj.flux['brz'].shape, 'shape of flux[\"brz\"]')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Seems logical: 5000 DESI fibers, 10 petals, so 500 entries per petal."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `TARGETID` (which is intended to be unique for each source) is useful for mapping source spectra to redshift. Let's extract all sources that were targeted as SV-like quasars in mini-SV-2 (the bit-name `SV0_QSO`; not to be confused with the Main-Survey-like quasars that were targeted as `MINI_SV_QSO`) using the fibermap information from the spectral file, and plot the first 20."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "qsos = np.where(specobj.fibermap[\"CMX_TARGET\"] & cmx_mask[\"SV0_QSO\"])[0]\n",
+    "print(len(qsos), 'QSOs')\n",
+    "plt.figure(figsize=(25,15))\n",
+    "xmin, xmax = np.min(wave), np.max(wave)\n",
+    "for i in range(len(qsos))[0:9]:\n",
+    "    plt.subplot(3,3,i+1)\n",
+    "    ymin, ymax = np.min(flux[qsos[i]][30:50]), np.max(flux[qsos[i]][0:50])\n",
+    "    plt.axis([xmin, xmax, ymin, ymax])\n",
+    "    plt.plot(wave, flux[qsos[i]],'b', alpha=0.5)\n",
+    "    # plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "I definitely see some broad emission lines! Let's match these quasar targets to the redshift file on `TARGETID` to extract their best-fit redshifts from `redrock`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dd = defaultdict(list)\n",
+    "for index, item in enumerate(zs[\"TARGETID\"]):\n",
+    "    dd[item].append(index)\n",
+    "zqsos = [index for item in fm[qsos][\"TARGETID\"] for index in dd[item] if item in dd]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "That might be hard to follow at first glance, but all I did was use some \"standard\" python syntax to match the indices in `zs` (the ordering of objects in the `redrock` redshift file) to those for quasars in `fm` (the ordering of quasars in the fibermap file), on the unique `TARGETID`, such that the indices stored in `qsos` for `fm` point to the corresponding indices in `zqsos` for `zs`. This might help illustrate the result:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zs[zqsos][\"TARGETID\"][0:7], np.array(fm[qsos][\"TARGETID\"][0:7])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's see what best-fit template `redrock` assigned to each quasar target. This information is stored in the `SPECTYPE` column."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zs[zqsos][\"SPECTYPE\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Or for standard stars:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dd = defaultdict(list)\n",
+    "for index, item in enumerate(zs[\"TARGETID\"]):\n",
+    "    dd[item].append(index)\n",
+    "zstds = [index for item in fm[stds][\"TARGETID\"] for index in dd[item] if item in dd]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For stars, we can also display the type of star that `redrock` fit (this is stored in the `SUBTYPE` column):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipper = zip(zs[zstds][\"SUBTYPE\"][10:15], zs[zstds][\"SPECTYPE\"][10:15])\n",
+    "for sub, spec in zipper:\n",
+    "    print(\"{}-{}\".format(sub.decode('utf-8'),spec.decode('utf-8')))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here, I just picked 5 correctly identified stars as an example. Note that the conversion to `utf-8` is simply for display purposes because the strings in `SUBTYPE` and `SPECTYPE` are stored as bytes instead of unicode."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "OK, back to our quasars. Let's plot the quasar targets that *are identified as quasars* , but add a label for the `SPECTYPE` and the redshift fit by `redrock`. I'll also add some median filtering and over-plot some (approximate) typical quasar emission lines at the redrock redshift (if those lines would fall in the DESI wavelength coverage):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from scipy.signal import medfilt\n",
+    "\n",
+    "# ADM we'll clip to z < 5, as redrock can misidentify low S/N sources as very-high-z quasars.\n",
+    "qsoid = np.where( (zs[zqsos][\"SPECTYPE\"] == b'QSO') & (zs[zqsos][\"Z\"] < 5) )[0]\n",
+    "qsolines = np.array([1216, 1546, 1906, 2800, 4853, 4960, 5008])\n",
+    "\n",
+    "wave = specobj.wave[\"brz\"]\n",
+    "flux = specobj.flux[\"brz\"]\n",
+    "plt.figure(figsize=(25, 15))\n",
+    "for i in range(9):\n",
+    "    plt.subplot(3,3,1+i)\n",
+    "    spectype = zs[zqsos[qsoid[i]]][\"SPECTYPE\"].decode('utf-8')\n",
+    "    z = zs[zqsos[qsoid[i]]][\"Z\"]\n",
+    "    plt.plot(wave, medfilt(flux[qsos[qsoid[i]]], 15), 'b', alpha=0.5)\n",
+    "    plt.title(\"{}, z={:.3f}\".format(spectype,z))\n",
+    "    for line in qsolines:\n",
+    "        if ((1+z)*line > np.min(wave)) & ((1+z)*line < np.max(wave)):\n",
+    "            axvline((1+z)*line, color='y', alpha=0.5)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Appendix: code versions used"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from desitutorials import print_code_versions as pcv\n",
+    "print(\"This tutorial last ran successfully to completion using the following versions of the following modules:\") \n",
+    "pcv()"
+   ]
+  }
+ ],
+ "metadata": {
+  "anaconda-cloud": {},
+  "kernelspec": {
+   "display_name": "DESI 19.12",
+   "language": "python",
+   "name": "desi-19.12"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/Intro_to_DESI_spectra.ipynb
+++ b/Intro_to_DESI_spectra.ipynb
@@ -10,6 +10,8 @@
     "\n",
     "If you identify any errors or have requests for additional functionality please create a new issue on https://github.com/desihub/tutorials/issues or send a note to desi-data@desi.lbl.gov.\n",
     "\n",
+    "Note that this tutorial specifically deals with simulated data that will resemble the DESI Main Survey. To learn how to work with real data in SV (and mini-SV) look at the _Introduction to DESI SV Spectra_ tutorial instead. (e.g. https://github.com/desihub/tutorials/blob/master/Intro_to_DESI_SV_spectra.ipynb).\n",
+    "\n",
     "Last updated January 2020 using DESI software release 19.12."
    ]
   },


### PR DESCRIPTION
The data model and directory structure is different in SV (and mini-SV) as compared to the main survey. This tutorial is a version of the `Intro_to_DESI_spectra.ipynb` tutorial that has been updated to reflect this different data model.