### PR TITLE
Update fiberassign notebooks to use a nominal focalplane

### DIFF
--- a/FiberAssign.ipynb
+++ b/FiberAssign.ipynb
@@ -40,6 +40,7 @@
     "%pylab inline\n",
     "import os, sys, subprocess\n",
     "from collections import Counter\n",
+    "from datetime import datetime\n",
     "\n",
     "import numpy as np\n",
     "from astropy.table import Table\n",
@@ -64,6 +65,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# You can set this to a local path if you have the software installed and a copy of the data.\n",
+    "# workdir = os.path.join(os.environ['HOME'], 'scratch', 'desi', 'tutorials', 'fiberassign_obs')\n",
     "workdir = os.path.join(os.environ['SCRATCH'], 'desi', 'test', 'fiberassign')\n",
     "os.makedirs(workdir, exist_ok=True)\n",
     "os.chdir(workdir)\n",
@@ -193,7 +196,17 @@
    "metadata": {},
    "source": [
     "Let's compare that tiling coverage to the fiber coverage.  We'll see that the coverage of\n",
-    "actual fibers (positioners) is less than that of the tile, and has a more complex spatial structure."
+    "actual fibers (positioners) is less than that of the tile, and has a more complex spatial structure.  By default, desimodel returns the realistic state of the focalplane at the time you run this notebook.  That is great for working in realtime on real data.  For this exercise, we will be using a focalplane from a time prior to commissioning so that we will have all positioners working and with their nominal properties."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rundatestr = \"2020-01-01T00:00:00\"\n",
+    "rundate = datetime.strptime(rundatestr, \"%Y-%m-%dT%H:%M:%S\")"
    ]
   },
   {
@@ -203,8 +216,11 @@
    "outputs": [],
    "source": [
     "def plot_positioners(tilera, tiledec, alpha=0.1):\n",
-    "    fiberpos = desimodel.io.load_fiberpos()\n",
-    "    ra, dec = desimodel.focalplane.xy2radec(tilera, tiledec, fiberpos['X'], fiberpos['Y'])\n",
+    "    fp, exclude, state, tmstr = desimodel.io.load_focalplane(time=rundate)\n",
+    "    # Select just science positioners\n",
+    "    rows = np.where(fp['DEVICE_TYPE'] == 'POS')[0]\n",
+    "    fp = fp[rows]\n",
+    "    ra, dec = desimodel.focalplane.xy2radec(tilera, tiledec, fp['OFFSET_X'], fp['OFFSET_Y'])\n",
     "    plot(ra, dec, '.', alpha=alpha)\n",
     "\n",
     "figure(figsize=(8,4))\n",
@@ -345,7 +361,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Run fiberassign on those targets/standards/sky"
+    "## Run fiberassign on those targets/standards/sky\n",
+    "\n",
+    "Fiberassign calls desimodel to get focalplane properties.  By default this uses the current time when you run this notebook.  Instead, we will use the same historical time above in order to get a nominal focalplane prior to commissioning will all positioners working."
    ]
   },
   {
@@ -355,6 +373,7 @@
    "outputs": [],
    "source": [
     "cmd = 'fiberassign --overwrite --mtl mtl.fits --stdstar stdstars.fits --sky sky.fits'\n",
+    "cmd += ' --rundate {}'.format(rundatestr)\n",
     "cmd += ' --footprint ./tiles.fits'\n",
     "cmd += ' --outdir ./output/'\n",
     "cmd = cmd.format(outdir=outdir)\n",
@@ -771,9 +790,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "DESI master",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "desi-master"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -785,7 +804,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.6"
+   "version": "3.7.5"
   }
  },
  "nbformat": 4,

--- a/FiberAssignDECaLS.ipynb
+++ b/FiberAssignDECaLS.ipynb
@@ -52,6 +52,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# You can set this to a local path if you have the software installed and a copy of the data.\n",
+    "# workdir = os.path.join(os.environ['HOME'], 'scratch', 'desi', 'tutorials', 'fiberassign_obs')\n",
     "workdir = os.path.join(os.environ['SCRATCH'], 'desi', 'test', 'fiberassign_obs')\n",
     "os.makedirs(workdir, exist_ok=True)\n",
     "os.chdir(workdir)\n",
@@ -72,6 +74,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Change this if you are running locally.\n",
+    "# paths = {\n",
+    "#     \"targets\": \"/home/kisner/scratch/desi/tutorials\", \n",
+    "#     \"skies\": \"/home/kisner/scratch/desi/tutorials\", \n",
+    "#     \"gfas\": \"/home/kisner/scratch/desi/tutorials\",\n",
+    "# }\n",
+    "\n",
     "paths = {\"targets\": \"/global/cfs/cdirs/desi/target/catalogs/dr8/0.31.1/targets/main/resolve/\", \n",
     "         \"skies\": \"/global/cfs/cdirs/desi/target/catalogs/dr8/0.32.0/skies/\", \n",
     "         \"gfas\": \"/global/cfs/cdirs/desi/target/catalogs/dr8/0.32.0/gfas/\",\n",
@@ -228,15 +237,32 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "By default, fiberassign uses the real focalplane geometry and properties at the current time.  During operations, if a fiber broke yesterday and you run fiberassign today with an up-to-date desimodel data checkout, then that fiber will not be assigned.  For this tutorial, we will run fiberassign with a *rundate* set to a time in the past before the start of commissioning.  This will give us a nominal focalplane layout with all positioners working."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "assign_date = \"2020-01-01T00:00:00\""
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "cmd = 'fiberassign --overwrite --mtl mtl.fits --sky sky.fits'\n",
-    "cmd += ' --footprint ./tiles.fits'\n",
-    "cmd += ' --outdir ./output/'\n",
-    "cmd = cmd.format(outdir=outdir)\n",
+    "cmd += ' --rundate {}'.format(assign_date)\n",
+    "cmd += ' --footprint {}'.format(tilefile)\n",
+    "cmd += ' --outdir {}'.format(outdir)\n",
+    "\n",
     "print(cmd)"
    ]
   },
@@ -275,8 +301,8 @@
     "# Gather all outputs\n",
     "assignments = list()\n",
     "for tileid in tiles['TILEID']:\n",
-    "    tilefile = '{}/fiberassign-{:06d}.fits'.format(outdir, tileid)\n",
-    "    assignments.append(Table.read(tilefile, hdu=1))\n",
+    "    outtile = '{}/fiberassign-{:06d}.fits'.format(outdir, tileid)\n",
+    "    assignments.append(Table.read(outtile, hdu=1))\n",
     "    \n",
     "assigned_targetids = np.concatenate([tmp['TARGETID'] for tmp in assignments])\n",
     "isAssigned = np.in1d(targets['TARGETID'], assigned_targetids)\n",
@@ -300,13 +326,76 @@
     "plt.xlabel('RA [deg]')\n",
     "plt.ylabel('DEC [deg]')"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can now run some basic QA on these outputs.  We run this on the merged outputs so that we have access to more target information."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cmd = 'fba_run_qa --prefix fiberassign-'\n",
+    "cmd += ' --rundate {}'.format(assign_date)\n",
+    "cmd += ' --footprint {}'.format(tilefile)\n",
+    "cmd += ' --dir {}'.format(outdir)\n",
+    "\n",
+    "print(cmd)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print('RUNNING: '+cmd)\n",
+    "try:\n",
+    "    results = subprocess.check_output(cmd.split(), stderr=subprocess.STDOUT)\n",
+    "    print(results.decode())\n",
+    "    print('--- SUCCESS ---')\n",
+    "except subprocess.CalledProcessError as ex:\n",
+    "    print('--- ERROR {} ---'.format(ex.returncode))\n",
+    "    print(ex.output.decode())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Load the results back in and print\n",
+    "import json\n",
+    "from pprint import PrettyPrinter\n",
+    "\n",
+    "qa_file = os.path.join(outdir, \"qa.json\")\n",
+    "qa_data = None\n",
+    "with open(qa_file, \"r\") as f:\n",
+    "    qa_data = json.load(f)\n",
+    "\n",
+    "pp = PrettyPrinter(indent=2)\n",
+    "pp.pprint(qa_data)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "DESI master",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "desi-master"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -318,7 +407,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.6"
+   "version": "3.7.5"
   }
  },
  "nbformat": 4,

--- a/FiberAssignMocks.ipynb
+++ b/FiberAssignMocks.ipynb
@@ -188,6 +188,22 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "By default, fiberassign uses the real focalplane geometry and properties at the current time.  During operations, if a fiber broke yesterday and you run fiberassign today with an up-to-date desimodel data checkout, then that fiber will not be assigned.  For this tutorial, we will run fiberassign with a *rundate* set to a time in the past before the start of commissioning.  This will give us a nominal focalplane layout with all positioners working."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "assign_date = \"2020-01-01T00:00:00\""
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -195,6 +211,7 @@
    "source": [
     "# Run fiberassign\n",
     "cmd = 'fiberassign --overwrite --mtl mtl-dark.fits --sky sky.fits'\n",
+    "cmd += ' --rundate {}'.format(assign_date)\n",
     "cmd += ' --footprint ./tiles.fits'\n",
     "cmd += ' --outdir ./output/'\n",
     "cmd = cmd.format(outdir=outdir)"
@@ -281,9 +298,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "DESI master",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "desi-master"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -295,7 +312,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.6"
+   "version": "3.7.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This updates the notebooks to use a fixed, pre-commissioning nominal focalplane, rather than just the current "live" focalplane.  These should be further modified once https://github.com/desihub/fiberassign/issues/260 is resolved.