### PR TITLE
Tutorial on subselecting and combining spectra

### DIFF
--- a/getting_started/SubselectSpectra.ipynb
+++ b/getting_started/SubselectSpectra.ipynb
@@ -1,0 +1,664 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "9d4769f5-088c-4d53-b776-d1dd75f7d6c4",
+   "metadata": {},
+   "source": [
+    "# Sub-selecting DESI Spectra\n",
+    "\n",
+    "If your analysis requires only a small subset of DESI spectra, it can be useful\n",
+    "to subselect the spectra of interest ahead of time and save those separately so\n",
+    "that subsequent analysis steps can start with a much smaller curated file instead\n",
+    "of re-reading and re-filtering the original files every time.\n",
+    "\n",
+    "This tutorial shows some utility features in desispec for reading, sub-selecting,\n",
+    "combining, and writing spectra.  It also shows how to associate a catalog with\n",
+    "spectra that can be written to the same output file and read back in.\n",
+    "\n",
+    "*Stephen Bailey (LBL)*<br/>\n",
+    "*September 2023*"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "41491c25-c8a8-495b-adc2-ea5f179f3c4d",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import numpy as np\n",
+    "import desispec.io\n",
+    "from desispec.spectra import stack"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7773aaf4-c5dc-4c12-8b81-479cc6c50b9e",
+   "metadata": {},
+   "source": [
+    "## Slicing (sub-selecting) Spectra\n",
+    "\n",
+    "`desispec.io.read_spectra(filename)` returns a `Spectra` object that can be sliced (sub-selected) using notation like numpy arrays.  We'll start by reading an example coadd spectra file from the \"fuji\" production included with the DESI Early Data Release (EDR)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "eeb9d7c9-4f72-481d-bcb1-1b6b256b69e6",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:spectra.py:372:read_spectra: iotime 1.054 sec to read coadd-0-100-thru20210505.fits at 2023-09-20T16:10:36.738042\n",
+      "There are 500 spectra in coadd-0-100-thru20210505.fits\n"
+     ]
+    }
+   ],
+   "source": [
+    "fujidir = os.path.expandvars('$DESI_ROOT/spectro/redux/fuji')\n",
+    "specfile = f'{fujidir}/tiles/cumulative/100/20210505/coadd-0-100-thru20210505.fits'\n",
+    "spectra = desispec.io.read_spectra(specfile)\n",
+    "print('There are {} spectra in {}'.format(spectra.num_spectra(), os.path.basename(specfile)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ce078352-c7c4-46e1-93c4-aa50e1d2fb2f",
+   "metadata": {},
+   "source": [
+    "Spectra can be sliced like numpy arrays using arrays of booleans, arrays of integer indices, or Python slices."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "da4a160b-366f-4a38-a475-0b6e2e53ef51",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Original number of spectra: 500\n",
+      "\n",
+      "Subset 1 selected with boolean array FIBER%50==0 -> 10 spectra\n",
+      "FIBER      TARGETID     \n",
+      "----- ------------------\n",
+      "    0 616094145466860255\n",
+      "   50  39633393171825713\n",
+      "  100  39633399102572725\n",
+      "  150  39633390172898751\n",
+      "  200  39633396153974983\n",
+      "  250  39633399102574156\n",
+      "  300  39633390181286972\n",
+      "  350  39633396153976678\n",
+      "  400  39633404941045627\n",
+      "  450  39633393176021808\n",
+      "\n",
+      "Subset 2 selected with index array [10, 30, 452] -> 3 spectra\n",
+      "TARGETIDs match: True\n",
+      "FIBER      TARGETID    \n",
+      "----- -----------------\n",
+      "   10 39633396149780852\n",
+      "   30 39633396145589048\n",
+      "  452 39633390177093311\n",
+      "\n",
+      "Subset 3 selected with spectra[10:15] -> 5 spectra\n",
+      "TARGETIDs match: True\n",
+      "FIBER      TARGETID     \n",
+      "----- ------------------\n",
+      "   10  39633396149780852\n",
+      "   11           -1000237\n",
+      "   12  39633396149781848\n",
+      "   13  39633396149780580\n",
+      "   14 616094148449009805\n"
+     ]
+    }
+   ],
+   "source": [
+    "print('Original number of spectra:', spectra.num_spectra())\n",
+    "print()\n",
+    "\n",
+    "# subset with boolean array\n",
+    "keep = spectra.fibermap['FIBER'] % 50 == 0\n",
+    "subset1 = spectra[keep]\n",
+    "print('Subset 1 selected with boolean array FIBER%50==0 -> {} spectra'.format(subset1.num_spectra()))\n",
+    "print(subset1.fibermap['FIBER', 'TARGETID'])\n",
+    "print()\n",
+    "\n",
+    "# subset with integer indices\n",
+    "keep_indices = [10,30,452]\n",
+    "subset2 = spectra[keep_indices]\n",
+    "print('Subset 2 selected with index array {} -> {} spectra'.format(keep_indices, subset2.num_spectra()))\n",
+    "\n",
+    "# confirm that these actually match the original subset\n",
+    "ok = np.all(spectra.fibermap['TARGETID'][keep_indices] == subset2.fibermap['TARGETID'])\n",
+    "print('TARGETIDs match:', ok)\n",
+    "print(subset2.fibermap['FIBER', 'TARGETID'])\n",
+    "print()\n",
+    "\n",
+    "# subset with Python slice notation\n",
+    "subset3 = spectra[10:15]\n",
+    "print('Subset 3 selected with spectra[10:15] -> {} spectra'.format(subset3.num_spectra()))\n",
+    "\n",
+    "ok = np.all(spectra.fibermap['TARGETID'][10:15] == subset3.fibermap['TARGETID'])\n",
+    "print('TARGETIDs match:', ok)\n",
+    "print(subset3.fibermap['FIBER', 'TARGETID'])\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8ce46c2d-ce15-4b3e-a6f9-3fb7ea53ad25",
+   "metadata": {},
+   "source": [
+    "## Stacking spectra\n",
+    "\n",
+    "Multiple Spectra objects can be re-combined into a single Spectra\n",
+    "object using `desispec.spectra.stack(list_of_spectra)`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "7b39d5b8-4269-456c-bcb5-2aa089ee73be",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "combined_spectra has 18 spectra, generated from subsets with 10, 3, and 5 spectra\n"
+     ]
+    }
+   ],
+   "source": [
+    "combined_spectra = stack([subset1, subset2, subset3])\n",
+    "\n",
+    "print('combined_spectra has {} spectra, generated from subsets with {}, {}, and {} spectra'.format(\n",
+    "    combined_spectra.num_spectra(), subset1.num_spectra(), subset2.num_spectra(), subset3.num_spectra()))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "441921b2-6fc4-4d28-a684-dbf50ace62ef",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## Exercise\n",
+    "\n",
+    "Note that index 10 is included in both subset2 (indices 10,30,452) and subset3 (slice 10:15).\n",
+    "Check `combined_spectra.fibermap['FIBER', 'TARGETID']` to see if it is duplicated in the\n",
+    "stacked spectra or not.\n",
+    "If needed, how would you remove duplicates from input subsets prior to stacking?"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8cb6ea90-c365-41da-9c1a-a328a22cfaa1",
+   "metadata": {},
+   "source": [
+    "## Sorting spectra\n",
+    "\n",
+    "The same index slice notation can be used to sort Spectra objects."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "9918a2f2-c443-49ef-b47c-048cf8e08d39",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Original order of the spectra:\n",
+      "     TARGETID      FOCALPLANE_RADIUS\n",
+      "------------------ -----------------\n",
+      "616094145466860255          301.6674\n",
+      " 39633393171825713         275.26178\n",
+      " 39633399102572725         186.94934\n",
+      " 39633390172898751         341.90472\n",
+      " 39633396153974983         234.18489\n",
+      " 39633399102574156         183.96696\n",
+      " 39633390181286972         385.61755\n",
+      " 39633396153976678         258.99908\n",
+      " 39633404941045627         32.213264\n",
+      " 39633393176021808          339.2598\n",
+      "\n",
+      "Order after sorting by focal plane radius:\n",
+      "     TARGETID      FOCALPLANE_RADIUS\n",
+      "------------------ -----------------\n",
+      " 39633404941045627         32.213264\n",
+      " 39633399102574156         183.96696\n",
+      " 39633399102572725         186.94934\n",
+      " 39633396153974983         234.18489\n",
+      " 39633396153976678         258.99908\n",
+      " 39633393171825713         275.26178\n",
+      "616094145466860255          301.6674\n",
+      " 39633393176021808          339.2598\n",
+      " 39633390172898751         341.90472\n",
+      " 39633390181286972         385.61755\n"
+     ]
+    }
+   ],
+   "source": [
+    "focalplane_radius = np.sqrt(subset1.fibermap['MEAN_FIBER_X']**2 + subset1.fibermap['MEAN_FIBER_Y']**2)\n",
+    "subset1.fibermap['FOCALPLANE_RADIUS'] = focalplane_radius\n",
+    "\n",
+    "print('Original order of the spectra:')\n",
+    "print(subset1.fibermap['TARGETID', 'FOCALPLANE_RADIUS'])\n",
+    "\n",
+    "sort_indices = np.argsort(focalplane_radius)\n",
+    "subset1 = subset1[sort_indices]\n",
+    "print('\\nOrder after sorting by focal plane radius:')\n",
+    "print(subset1.fibermap['TARGETID', 'FOCALPLANE_RADIUS'])\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "12798e06-1d89-4334-a9cc-b05a81e77522",
+   "metadata": {},
+   "source": [
+    "## Writing spectra\n",
+    "\n",
+    "You can use `desispec.io.write_spectra` to write specta to a separate file\n",
+    "for subsequent analysis.  Here we'll write it to a file and then\n",
+    "read it back in to confirm we get the same thing."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "bbd88678-8b1a-4659-8d13-1a36a8f91f16",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:spectra.py:184:write_spectra: iotime 0.080 sec to write desi_spectra_subset.fits at 2023-09-20T16:10:37.204075\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "'/pscratch/sd/s/sjbailey/desi_spectra_subset.fits'"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "outfile = os.path.expandvars('$SCRATCH/desi_spectra_subset.fits')\n",
+    "desispec.io.write_spectra(outfile, combined_spectra)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "25642926-573b-4451-9105-76bd3d4de171",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:spectra.py:372:read_spectra: iotime 0.023 sec to read desi_spectra_subset.fits at 2023-09-20T16:10:37.235220\n",
+      "TARGETIDs match: True\n",
+      "fluxes match: True\n"
+     ]
+    }
+   ],
+   "source": [
+    "newspec = desispec.io.read_spectra(outfile)\n",
+    "ok = np.all(combined_spectra.fibermap['TARGETID'] == newspec.fibermap['TARGETID'])\n",
+    "print('TARGETIDs match:', ok)\n",
+    "\n",
+    "ok = np.all(combined_spectra.flux['b'] == newspec.flux['b'])\n",
+    "print('fluxes match:', ok)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6988628f-e4f0-449d-839f-cafa3551932c",
+   "metadata": {},
+   "source": [
+    "## Worked example: Bright QSO subset\n",
+    "\n",
+    "In this worked example, we'll find the 10 brightest z>2 QSOs in the SV1 survey DARK program,\n",
+    "read them in from their individual files, coadd them across cameras, and combine them\n",
+    "into a single Spectrum object to write to a separate file for further analysis.\n",
+    "\n",
+    "In this case, we will already know the TARGETIDs that we want from the redshift catalog,\n",
+    "so we'll make use of `read_spectra(filename, targetids=...)` to read just the subset of\n",
+    "TARGETIDs that we want, instead of having to read the entire file and subselect the\n",
+    "spectra post-factor.\n",
+    "\n",
+    "This section will also show how to associate the redshift catalog subset to the spectra so that\n",
+    "it can be written and read back in along with the spectra themselves, instead of having to be\n",
+    "tracked separately."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "ddf22021-0a21-4443-89d4-0a954d7a1073",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import fitsio\n",
+    "from astropy.table import Table\n",
+    "from desispec.coaddition import coadd_cameras"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "2e364add-7664-47eb-b085-fe64352d4579",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Read the sv1-dark combined redshift catalog across all tiles\n",
+    "os.environ['SPECPROD'] = 'fuji'\n",
+    "fujidir = os.path.expandvars('$DESI_ROOT/spectro/redux/fuji')\n",
+    "zcatfile = f'{fujidir}/zcatalog/ztile-sv1-dark-cumulative.fits'\n",
+    "zcat = fitsio.read(zcatfile, 'ZCATALOG', columns=('TARGETID', 'TILEID', 'LASTNIGHT', 'PETAL_LOC', 'SPECTYPE', 'Z', 'ZWARN', 'FLUX_G'))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "2c8ceed2-c12e-494f-a679-14b2043e044c",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# subselect to confident z>2 QSOs\n",
+    "keep = (zcat['SPECTYPE']=='QSO') & (zcat['ZWARN']==0) & (zcat['Z']>2)\n",
+    "zcat = zcat[keep]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "5595373e-f322-47b1-a78d-7e0de3608fb1",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     TARGETID     LASTNIGHT         Z          ... PETAL_LOC   FLUX_G   TILEID\n",
+      "----------------- --------- ------------------ ... --------- ---------- ------\n",
+      "39628170290268893  20210404 2.0050244697713833 ...         6  59.962227  80893\n",
+      "39633315216492822  20210222  2.259111679446162 ...         4  61.812695  80712\n",
+      "39628523018653064  20210406 2.5714594724078568 ...         9    65.7126  80897\n",
+      "39627217130493416  20210116  2.544975906861089 ...         1    65.9629  80674\n",
+      "39628526546061698  20210109 2.6987046629928293 ...         2   70.07165  80682\n",
+      "39628511480121439  20210318 2.0897803029105906 ...         1  73.675964  80698\n",
+      "39628438411150843  20210318 2.0771515712878044 ...         7   74.12616  80856\n",
+      "39628454605358968  20210221  2.866434757277841 ...         5   88.01636  80708\n",
+      "39628210912103893  20210321  2.755069936210957 ...         3 118.559364  80859\n",
+      "39632950383345740  20210318 2.5001202098916853 ...         5  129.35292  80698\n"
+     ]
+    }
+   ],
+   "source": [
+    "# sort by FLUX_G and print the brightest 10\n",
+    "ii = np.argsort(zcat['FLUX_G'])\n",
+    "bright_qso_zcat = Table(zcat[ii[-10:]])\n",
+    "print(bright_qso_zcat)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "45bb49ba-39e3-4f4b-981f-8edde0a4cafa",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:spectra.py:372:read_spectra: iotime 0.659 sec to read coadd-1-80674-thru20210116.fits at 2023-09-20T16:10:38.342144\n",
+      "INFO:spectra.py:372:read_spectra: iotime 0.884 sec to read coadd-2-80682-thru20210109.fits at 2023-09-20T16:10:39.264098\n",
+      "INFO:spectra.py:372:read_spectra: iotime 0.731 sec to read coadd-1-80698-thru20210318.fits at 2023-09-20T16:10:40.012767\n",
+      "INFO:spectra.py:372:read_spectra: iotime 0.800 sec to read coadd-5-80698-thru20210318.fits at 2023-09-20T16:10:40.831705\n",
+      "INFO:spectra.py:372:read_spectra: iotime 0.907 sec to read coadd-5-80708-thru20210221.fits at 2023-09-20T16:10:41.757240\n",
+      "INFO:spectra.py:372:read_spectra: iotime 0.865 sec to read coadd-4-80712-thru20210222.fits at 2023-09-20T16:10:42.640857\n",
+      "INFO:spectra.py:372:read_spectra: iotime 0.479 sec to read coadd-7-80856-thru20210318.fits at 2023-09-20T16:10:43.138647\n",
+      "INFO:spectra.py:372:read_spectra: iotime 1.036 sec to read coadd-3-80859-thru20210321.fits at 2023-09-20T16:10:44.193095\n",
+      "INFO:spectra.py:372:read_spectra: iotime 0.825 sec to read coadd-6-80893-thru20210404.fits at 2023-09-20T16:10:45.035760\n",
+      "INFO:spectra.py:372:read_spectra: iotime 0.982 sec to read coadd-9-80897-thru20210406.fits at 2023-09-20T16:10:46.035648\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Loop over the files that contain these targets and assemble the subsets.\n",
+    "# Note the use of read_spectra(filename, targetids=...) to filter while reading,\n",
+    "# instead of reading the entire file and filtering afterward.\n",
+    "spectra_list = list()\n",
+    "for tileid, night, petal in np.unique(bright_qso_zcat['TILEID', 'LASTNIGHT', 'PETAL_LOC']):\n",
+    "    coaddfile = desispec.io.findfile('coadd', tile=tileid, night=night, spectrograph=petal,\n",
+    "                                     groupname='cumulative')\n",
+    "    spectra = desispec.io.read_spectra(coaddfile, targetids=bright_qso_zcat['TARGETID'])\n",
+    "    spectra_camcoadd = coadd_cameras(spectra)\n",
+    "    spectra_list.append(spectra_camcoadd)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "61c956b2-bf26-4e78-a7b6-eb4eb730836b",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# stack those N>>1 subsets into a single Spectrum object\n",
+    "best_spectra = stack(spectra_list)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "09783490-17a7-4b73-a93c-d72d275988d0",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Sort both the spectra and the zcat by TARGETID so that they\n",
+    "# are row-matched, and then attach zcat to spectra so that it\n",
+    "# will be included in output file\n",
+    "ii = np.argsort(best_spectra.fibermap['TARGETID'])\n",
+    "best_spectra = best_spectra[ii]\n",
+    "\n",
+    "jj = np.argsort(bright_qso_zcat['TARGETID'])\n",
+    "bright_qso_zcat = bright_qso_zcat[jj]\n",
+    "\n",
+    "assert np.all(best_spectra.fibermap['TARGETID'] == bright_qso_zcat['TARGETID'])\n",
+    "\n",
+    "best_spectra.extra_catalog = bright_qso_zcat"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "6c336711-b440-4046-8369-5aab2af31bc8",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:spectra.py:184:write_spectra: iotime 0.056 sec to write desi_bright_qso.fits at 2023-09-20T16:10:46.267363\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "'/pscratch/sd/s/sjbailey/desi_bright_qso.fits'"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# write output for further analysis\n",
+    "outfile = os.path.expandvars('$SCRATCH/desi_bright_qso.fits')\n",
+    "desispec.io.write_spectra(outfile, best_spectra)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "66580eea-43e0-4855-9d1d-708f9f07e6dc",
+   "metadata": {},
+   "source": [
+    "Read it back in.\n",
+    "The bright_qso_zcat that we attached to the stacked spectra before\n",
+    "writing is now included as `qso.extra_catalog`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "ff152c1b-c6ba-4094-9092-2c537ba41447",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:spectra.py:372:read_spectra: iotime 0.021 sec to read desi_bright_qso.fits at 2023-09-20T16:10:46.293740\n",
+      "     TARGETID     LASTNIGHT         Z          ... PETAL_LOC   FLUX_G   TILEID\n",
+      "----------------- --------- ------------------ ... --------- ---------- ------\n",
+      "39627217130493416  20210116  2.544975906861089 ...         1    65.9629  80674\n",
+      "39628170290268893  20210404 2.0050244697713833 ...         6  59.962227  80893\n",
+      "39628210912103893  20210321  2.755069936210957 ...         3 118.559364  80859\n",
+      "39628438411150843  20210318 2.0771515712878044 ...         7   74.12616  80856\n",
+      "39628454605358968  20210221  2.866434757277841 ...         5   88.01636  80708\n",
+      "39628511480121439  20210318 2.0897803029105906 ...         1  73.675964  80698\n",
+      "39628523018653064  20210406 2.5714594724078568 ...         9    65.7126  80897\n",
+      "39628526546061698  20210109 2.6987046629928293 ...         2   70.07165  80682\n",
+      "39632950383345740  20210318 2.5001202098916853 ...         5  129.35292  80698\n",
+      "39633315216492822  20210222  2.259111679446162 ...         4  61.812695  80712\n"
+     ]
+    }
+   ],
+   "source": [
+    "# confirm that we can read it back in\n",
+    "qsos = desispec.io.read_spectra(outfile)\n",
+    "print(qsos.extra_catalog)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "dec47697-0ce4-46af-8bea-4020ff852ea6",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAjsAAAGwCAYAAABPSaTdAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjYuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8o6BhiAAAACXBIWXMAAA9hAAAPYQGoP6dpAACwv0lEQVR4nOz9eZRkV3Xg/37PnWLOyHmqWVJpoiQkS0IgMwsEcmOawYY23W7oH4/nNsNqFqbpRXv9eumtXz+w/Z6x+2ca+pmmwYBBxjSjkQGBhEBIAg1oKA1VpZor5zHm4d57zvvjRkZmZEZWZZayKrOK/dFKVca9N+49MWTGznP22UcZYwxCCCGEEBcpa7MbIIQQQghxLkmwI4QQQoiLmgQ7QgghhLioSbAjhBBCiIuaBDtCCCGEuKhJsCOEEEKIi5oEO0IIIYS4qDmb3YCtQGvN6OgomUwGpdRmN0cIIYQQa2CMoVAoMDw8jGWt3n8jwQ4wOjrKjh07NrsZQgghhDgLJ0+eZPv27avul2AHyGQyQPRkdXR0bHJrhBBCCLEW+XyeHTt2ND/HVyPBDjSHrjo6OiTYEUIIIS4wZ0pBkQRlIYQQQlzUJNgRQgghxEVNgh0hhBBCXNQk2BFCCCHERU2CHSGEEEJc1CTYEUIIIcRFTYIdIYQQQlzUJNgRQgghxEVNgh0hhBBCXNQk2BFCCCHERU2CHSGEEEJc1CTYEUIIIcRFTYIdcfZCf7NbIIQQQpyRBDvi7Jx6FH72/4WJpze7JUIIIcRpSbAjzs6hH0X/PvPdzW2HEEIIcQYS7IizEpqACXOYkpnf7KYIIYQQpyXBjjgrc4xSYp4JDm92U4QQQojTkmBHnJUQH6PNZjdDCCGEOCNnsxsgLkz1iQLl3ATeQHazmyKEEEKclvTsiLNSPTULQH0it8ktEUIIIU5Pgh0hhBBCXNQk2BFCCCHERU2CHSGEEEJc1CTYEUIIIcRFTYIdcVYUqvmdEEIIsZVJsCOEEEKIi5oEO0IIIYS4qEmwI4QQQoiLmgQ7QgghhLioSbAjhBBCiIuaBDtCCCGEuKhJsCOEEEKIi5oEO0IIIYS4qEmwI4QQQoiL2qYGO5/85Ce56aabyGQy9Pf385a3vIUDBw60HPOe97wHpVTL10tf+tKWY2q1Gh/60Ifo7e0llUrx5je/mVOnTp3Ph/Kbx2x2A4QQQoi12dRg57777uMDH/gADz30EHfffTdBEHDbbbdRKpVajnvjG9/I2NhY8+uuu+5q2f/hD3+Yb33rW9x5553cf//9FItF3vSmNxGG4fl8OEIIIYTYgpzNvPgPfvCDlttf+MIX6O/v59FHH+WVr3xlc3ssFmNwcLDtOXK5HJ///Of58pe/zOte9zoAvvKVr7Bjxw5+/OMf84Y3vGHFfWq1GrVarXk7n89vxMMRQgghxBa0pXJ2crkcAN3d3S3bf/rTn9Lf38/ll1/O+973PiYnJ5v7Hn30UXzf57bbbmtuGx4eZt++fTzwwANtr/PJT36SbDbb/NqxY8c5eDRCCCGE2Aq2TLBjjOEjH/kIL3/5y9m3b19z++23387f//3fc8899/CXf/mXPPzww7z2ta9t9syMj4/jeR5dXV0t5xsYGGB8fLzttT7+8Y+Ty+WaXydPnjx3D+xiJYueCyGEuEBs6jDWUh/84Ad58sknuf/++1u2v/Od72x+v2/fPm688UZ27drF97//fd72tretej5jDEq1/ySOxWLEYrGNabgQQgghtrQt0bPzoQ99iO9+97vce++9bN++/bTHDg0NsWvXLg4dOgTA4OAg9Xqdubm5luMmJycZGBg4Z20WQgghxIVhU4MdYwwf/OAH+eY3v8k999zDnj17znifmZkZTp48ydDQEAA33HADruty9913N48ZGxtj//793HLLLees7UIIIYS4MGzqMNYHPvABvvrVr/Kd73yHTCbTzLHJZrMkEgmKxSJ33HEHb3/72xkaGuLYsWP85//8n+nt7eWtb31r89j3vve9/Mmf/Ak9PT10d3fz0Y9+lGuuuaY5O0sIIYQQv7k2Ndj57Gc/C8CrX/3qlu1f+MIXeM973oNt2zz11FN86UtfYn5+nqGhIV7zmtfwD//wD2Qymebxf/VXf4XjOLzjHe+gUqlw66238sUvfhHbts/nwxFCCCHEFqSMMb/xtXDz+TzZbJZcLkdHR8dmN+eC8Pz/5zYqmTIoxTV/9PPNbo4QQojfQGv9/N4SCcpCCCGEEOeKBDtCCCGEuKhJsCOEEEKIi5oEO0IIIYS4qEmwI4QQQoiLmgQ74qwEnr/ZTRBCCCHWRIIdcVb8mAQ7QgghLgwS7AghhBDioibBjhBCCCEuahLsCCGEEOKiJsGOEEIIIS5qEuwIIYQQ4qImwY4QQgghLmoS7IgXSG12A4QQQojTkmBHCCGEEBc1CXaEEEIIcVGTYEcIIYQQFzUJdoQQQghxUZNgRwghhBAXNQl2hBBCCHFRk2BHCCGEEBc1CXaEEEIIcVGTYEcIIYQQFzUJdsQLY/Rmt0AIIYQ4LQl2hBBCCHFRk2BHCCGEEBc1CXbEuhljNrsJQgghxJpJsCPWTedym90EIYQQYs0k2BFCCCHERU2CHbF+Si1+bzmb1w4hhBBiDSTYEeu3NGdnaeAjhBBCbEES7IgXTOvaZjdBCCGEWJUEO+IFm59/ZLObIIQQQqxKgh2xfstGroKwuDntEEIIIdZAgh3xgtWq45vdBCGEEGJVEuyIddO11hwdydkRQgixlUmwI9Zt7s47N7sJQgghxJpJsCOEEEKIi5oEO+IsyNpYQgghLhwS7IizsDzYkeBHCCHE1iXBjjgLEtwIIYS4cEiwI9bNyAoRQgghLiAS7Ij1M609O9LPI4QQYiuTYEcIIYQQFzUJdsQLZ6RvRwghxNYlwY44C3rZbQl2hBBCbF0S7AghhBDioibBjlg3o6QnRwghxIVDgh2xAST4EUIIsXVtarDzyU9+kptuuolMJkN/fz9vectbOHDgQMsxxhjuuOMOhoeHSSQSvPrVr+bpp59uOaZWq/GhD32I3t5eUqkUb37zmzl16tT5fCi/MYwxoIPWbRLsCCGE2MI2Ndi57777+MAHPsBDDz3E3XffTRAE3HbbbZRKpeYxf/EXf8GnPvUpPv3pT/Pwww8zODjI61//egqFQvOYD3/4w3zrW9/izjvv5P7776dYLPKmN72JMAw342Fd3IyB8sxmt0IIIYRYM2XM1pk3PDU1RX9/P/fddx+vfOUrMcYwPDzMhz/8Yf7Tf/pPQNSLMzAwwJ//+Z/zR3/0R+RyOfr6+vjyl7/MO9/5TgBGR0fZsWMHd911F294wxvOeN18Pk82myWXy9HR0XFOH+OFzoQhE3/xH5nq+lW0wXZJv+7t7Nnzwc1tmBBCiN84a/383lI5O7lcDoDu7m4Ajh49yvj4OLfddlvzmFgsxqte9SoeeOABAB599FF83285Znh4mH379jWPWa5Wq5HP51u+xBoZgzHSYyaEEOLCsWWCHWMMH/nIR3j5y1/Ovn37ABgfHwdgYGCg5diBgYHmvvHxcTzPo6ura9VjlvvkJz9JNpttfu3YsWOjH87FyxgojC7fuClNEUIIIdZiywQ7H/zgB3nyySf52te+tmKfUq0rTxpjVmxb7nTHfPzjHyeXyzW/Tp48efYN/01klhcVFEIIIbauLRHsfOhDH+K73/0u9957L9u3b29uHxwcBFjRQzM5Odns7RkcHKRerzM3N7fqMcvFYjE6OjpavsQaGcPynhzp1xFCCLGVbWqwY4zhgx/8IN/85je555572LNnT8v+PXv2MDg4yN13393cVq/Xue+++7jlllsAuOGGG3Bdt+WYsbEx9u/f3zxGbBwDcPpONSGEEGJLcTbz4h/4wAf46le/yne+8x0ymUyzByebzZJIJFBK8eEPf5hPfOIT7N27l7179/KJT3yCZDLJu971ruax733ve/mTP/kTenp66O7u5qMf/SjXXHMNr3vd6zbz4V2cts7kPSGEEGJNNjXY+exnPwvAq1/96pbtX/jCF3jPe94DwMc+9jEqlQrvf//7mZub4+abb+ZHP/oRmUymefxf/dVf4TgO73jHO6hUKtx666188YtfxLbt8/VQfnOYdiUEJQASQgixdW2pOjubRersrJ2uVBj/v/41Mzsnow22S+rWt3DJJf9hcxsmhBDiN84FWWdHbH3+2DjSkyOEEOJCIsGOWJdgcnKzmyCEEEKsiwQ7Yn2UAmtTU72EEEKIdZFgR6yPAqOWDGPJiJYQQogtToIdsS7tqlK3m58lhBBCbBUS7Ih1Ua6LdOcIIYS4kEiwI9bF7u1bVkHZSOwjhBBiS5NgR6yTaTNsJdGOEEKIrUuCHfHCSawjhBBiC5NgR6xPm1XPhRBCiK1Mgh2xPm1XF5HgRwghxNYlwY5Yv2UBj2LldHQhhBBiq5BgR6yPMbBsNflU8vJNaowQQghxZhLsiPUxBtKDLZuUslc5WAghhNh8EuyI9bNa3zbG6E1qiBBCCHFmEuyIdTHtEpS1BDtCCCG2Lgl2xPosj3V0gD8xsSlNEUIIIdZCgh2xLrpYaLNRenaEEEJsXRLsiHUp3vezlVV1JGdHCCHEFibBjjgLUkRQCCHEhUOCHfGC1fTUZjdBCCGEWJUEO+IFC3Rps5sghBBCrEqCHbF+K5N2NqMVQgghxJpIsCPWxd22bbObIIQQQqyLBDtiXbxdO1dulI4dIYQQW5gEO2J9jGH5IudWOr05bRFCCCHWQIIdsT7tlotQKzcJIYQQW4UEO2Jd2q6NJcNYQgghtjAJdsT6mOb/lm8UQgghtiQJdsT6GIMEN0IIIS4kEuyIdWo3jCXBjxBCiK1Lgh2xPhLYCCGEuMBIsCPWp22wIwGQEEKIrUuCHbEu7WZjmSDchJYIIYQQayPBjlifNp04/sjI+W+HEEIIsUYS7Ij1adez4/ub0BAhhBBibSTYEevUbuq55OwIIYTYuiTYEesjFZSFEEJcYCTYEevWZiBrE1ohhBBCrI0EO2J9pGdHCCHEBUaCHbEubRcClVXPhRBCbGES7Ij1aRPsOP39m9AQIYQQYm0k2BHr02bVc+U4m9IUIYQQYi0k2BHr1GbquayXJYQQYguTYEesT9sEZdM+l0cIIYTYAiTYEeuzSrAD+rw3RQghhFgLCXbEugQzsys31nLnvyFCCCHEGkmwI9YlmJxss7Emw1hCCCG2LAl2xAtm2szQEkIIIbYKCXbEC2faLQ4qhBBCbA2bGuz87Gc/43d/93cZHh5GKcW3v/3tlv3vec97UEq1fL30pS9tOaZWq/GhD32I3t5eUqkUb37zmzl16tR5fBS/idqtei7BjhBCiK1pU4OdUqnEi1/8Yj796U+veswb3/hGxsbGml933XVXy/4Pf/jDfOtb3+LOO+/k/vvvp1gs8qY3vYkwDM9188UCI6V2hBBCbF2bWvr29ttv5/bbbz/tMbFYjMHBwbb7crkcn//85/nyl7/M6173OgC+8pWvsGPHDn784x/zhje8YcPb/JtOuS74yzbKMJYQQogtbMvn7Pz0pz+lv7+fyy+/nPe9731MLpkN9Oijj+L7Prfddltz2/DwMPv27eOBBx5Y9Zy1Wo18Pt/yJdbG7ulus1WCHSGEEFvXlg52br/9dv7+7/+ee+65h7/8y7/k4Ycf5rWvfS21Wg2A8fFxPM+jq6ur5X4DAwOMj4+vet5PfvKTZLPZ5teOHTvO6eO46Pjl1tsyG0sIIcQWtqVXcHznO9/Z/H7fvn3ceOON7Nq1i+9///u87W1vW/V+xhiUUqvu//jHP85HPvKR5u18Pi8BzzqY6jxkl26Q5SKEEEJsXVu6Z2e5oaEhdu3axaFDhwAYHBykXq8zNzfXctzk5CQDAwOrnicWi9HR0dHyJdaoTVBjZBhLCCHEFnZBBTszMzOcPHmSoaEhAG644QZc1+Xuu+9uHjM2Nsb+/fu55ZZbNquZv3nCAAl2hBBCbFWbOoxVLBZ5/vnnm7ePHj3K448/Tnd3N93d3dxxxx28/e1vZ2hoiGPHjvGf//N/pre3l7e+9a0AZLNZ3vve9/Inf/In9PT00N3dzUc/+lGuueaa5uwssfGCWNC6oVbYnIYIIYQQa7Cpwc4jjzzCa17zmubthTyad7/73Xz2s5/lqaee4ktf+hLz8/MMDQ3xmte8hn/4h38gk8k07/NXf/VXOI7DO97xDiqVCrfeeitf/OIXsW37vD+e3xTlzmLrBiexOQ0RQggh1kAZySwln8+TzWbJ5XKSv3MGc1//Oqdm/++WbU5vL3vf8mUcJ7PKvYQQQoiNt9bP7wsqZ0dsAb/xobEQQogLjQQ74oWTzkEhhBBbmAQ74oVzU1JnRwghxJYlwY544U5TwFEIIYTYbBLsiHUxZuVq8sZApXpiE1ojhBBCnNlZBTuVSmXVfWNjY2fdGHEhWDlcFeYLlErPtzlWCCGE2HxnFexcf/31PPbYYyu2f+Mb3+Daa699wY0SW5dZbTqW5OwIIYTYos4q2Hn961/PLbfcwp/92Z9hjKFYLPKe97yHd7/73fyX//JfNrqNYktpE9TosP12IYQQYgs4qwrKf/M3f8O/+Bf/gn/37/4d3//+9xkdHaWjo4OHH36Yq6++eqPbKLYQo/SKbaqWR4IdIYQQW9VZLxdx22238ba3vY3PfvazOI7D9773PQl0fiO0CXZcWZpDCCHE1nVWw1iHDx/mZS97Gf/0T//ED3/4Qz72sY/xL//lv+RjH/sYvu9vdBvFFtI2Z8ecJpdHCCGE2GRnFexcd9117NmzhyeeeILXv/71/Nf/+l+55557+OY3v8lLXvKSjW6j2FLaBTVGRrGEEEJsWWcV7HzmM5/hzjvvpLOzs7ntlltu4de//jW/9Vu/tVFtE1vQ0h4cS0dvHxOTxVOFEEJsXWcV7PzhH/5h2+2ZTIbPf/7zL6hBYusyxhDMTjdvq3Dp20e6doQQQmxNZ5Wg/KUvfWnVfUqpVYMhcWHzR0ZoG9QY2m8XQgghtoCzCnb+w3/4Dy23fd+nXC7jeR7JZFKCnYuUqVRWSVA2kqAshBBiyzqrYay5ubmWr2KxyIEDB3j5y1/O1772tY1uo9gqLAvUagnKEuwIIYTYmjZsIdC9e/fyZ3/2Zyt6fcTFQ9k2MowlhBDiQrOhq57bts3o6OhGnlJsIWZZ780Jr59pO0s0R0uCHSGEEFvTWeXsfPe73225bYxhbGyMT3/60/z2b//2hjRMbEEGCKtgQ9FKcE/2eoxl+Leln292y4QQQohVnVWw85a3vKXltlKKvr4+Xvva1/KXf/mXG9EusRUZjZk6CIMwo2PUfI3jgdZacnaEEEJsWWcV7Gi9cn0k8RvAGAhqAPhh9B4ItMHUK0jOjhBCiK1qQ3N2xMXNaL3KbCwwRgJgIYQQW9Oae3Y+8pGPrPmkn/rUp86qMWKLW6XzRqNkGEsIIcSWteZg59e//vWajlNKnXVjxFa3GNBMxPqa3x+PDdLpz21Gg4QQQogzWnOwc++993LkyBF2796NZcno12+kJblaz6T2osLo+6oVk2EsIYQQW9a6opa9e/cyPb24EOQ73/lOJiYmNrxRYmsyyxLTfeLUjCLuz0t+shBCiC1rXcHO8qJyd911F6VSaUMbJLawJS9/iEtdxairJKVQZmMJIYTYumQ8SqydMdBIyTIodCPAMagVgbAQQgixVawr2FFKrUhAloTk3yBGt/TfmGawA2GlvClNEkIIIc5kXUUFjTG85z3vIRaLAVCtVvn3//7fk0qlWo775je/uXEtFFvHaXpvgkL+PDZECCGEWLt1BTvvfve7W27/m3/zbza0MWJrixKU2wQ8yiaU3C0hhBBb1LqCnS984Qvnqh3iQmCWfrt4wzce/sx0mzsIIYQQm08SlMXaGd1MUA6XBDuhtgh0sEmNEkIIIU5Pgh2xdktydpJhpWWXLbOxhBBCbFES7Ig1M77f/L5sJzAL3TwKAu2vci8hhBBic0mwI9as/MijLbeNit4+BkWuXtiMJgkhhBBnJMGO2DBSWFAIIcRWJMGOWDffaEIVBTZBKdUczjIm3MxmCSGEEG1JsCPWrWgW83OCUlRQMmbHJNgRQgixJa2rzo7YXKOjX6daHaO//42k01dsdnMaFAZFLaxhTADENrtBQgghRAvp2blAGBNSrY4BMDn5g81rh1pYDyvOQtEdrRv7jNTaEUIIsfVIsHOB2AqBhDs02Ha7NkkAKn7xfDZHCCGEWBMJdi4QegvXsdFEeTtfe+bLm9wSIYQQYiUJdi4QJ058frOb0FRdtjSEMdHbaMddj1MfH9+MJgkhhBCrkmBHrEstXcUA1pKaOkY33kbKMPedb29Ku4QQQojVSLAj1swYQzUdrYm1tHygwQIdoJRB12ub0zghhBBiFRLsiDULxieaQY5RqvmvMQr8CliGUEutHSGEEFuLBDsXqM1amqFiAlZc2SwsCGo4lT9xvpskhBBCnJYEO5us5Jc4Mn8EbfQ677l561A1VzsHtAU5Jx3dUIbZ6hy6VNqklgkhhBArbWqw87Of/Yzf/d3fZXh4GKUU3/72t1v2G2O44447GB4eJpFI8OpXv5qnn3665ZharcaHPvQhent7SaVSvPnNb+bUqVPn8VG8MF977mv84NgPeHbm2c1uypot71U6nhmOvmkUHCw/9tj5bpIQQgixqk0NdkqlEi9+8Yv59Kc/3Xb/X/zFX/CpT32KT3/60zz88MMMDg7y+te/nkKh0Dzmwx/+MN/61re48847uf/++ykWi7zpTW8iDLd27sh0ZZqvH/g69bAOwPH88XWeYfN7drQy0QjWkmEsgGByapNaJoQQQqy0qWtj3X777dx+++1t9xlj+Ou//mv+9E//lLe97W0A/N3f/R0DAwN89atf5Y/+6I/I5XJ8/vOf58tf/jKve93rAPjKV77Cjh07+PGPf8wb3vCG8/ZY1uuHx35IrpZr3jbrDF58P4fndW90s86gsVSEUmgLtDH4DjieHe1uBjsT57ldQgghxOq2bM7O0aNHGR8f57bbbmtui8VivOpVr+KBBx4A4NFHH8X3/ZZjhoeH2bdvX/OYdmq1Gvl8vuXrfKsElRd0f9+f35iGrIM2mrIOeKTjxpa8neao1sK6WeF684+EEEKIc2fLBjvjjUq8AwMDLdsHBgaa+8bHx/E8j66urlWPaeeTn/wk2Wy2+bVjx44Nbv36Hc8fZ6K09h6RiYnvncPWtDddnqJuQsZiwy3bVSPIsTpzqO45NPXz3jYhhBBiNVs22FmglGq5bYxZsW25Mx3z8Y9/nFwu1/w6efLkhrT1hfrfh/73ZjfhtIorFvqMnmPXW+ylsrJ5itsmz2OrhBBCiNPbssHO4GC0wvbyHprJyclmb8/g4CD1ep25ublVj2knFovR0dHR8iVOL5iaAn2mldejHp5qh1RRFkIIsXVs2WBnz549DA4Ocvfddze31et17rvvPm655RYAbrjhBlzXbTlmbGyM/fv3N4/ZqtZTFHCqPMVcbQ6D4UjuCBPl858ArGs1KJ7hukEU5JR9qbMjhBBi69jU2VjFYpHnn3++efvo0aM8/vjjdHd3s3PnTj784Q/ziU98gr1797J3714+8YlPkEwmede73gVANpvlve99L3/yJ39CT08P3d3dfPSjH+Waa65pzs7aisZL4/jab7vvfzzxP3jvNe/FtVwgCor+8eA/0lNefJ5mKjMMJFfvuTonjIFaof2uhRHDRmHEmYoMYwkhhNg6NjXYeeSRR3jNa17TvP2Rj3wEgHe/+9188Ytf5GMf+xiVSoX3v//9zM3NcfPNN/OjH/2ITCbTvM9f/dVf4TgO73jHO6hUKtx666188YtfxLbt8/541uqbh7656j5tND889kPedMmbAJgsb/3AwVgKbcBqDGP5oQxjCSGE2Do2Ndh59atffdrhHKUUd9xxB3fccceqx8Tjcf7mb/6Gv/mbvzkHLdwcJ/InmknWh+cPb3ZzImG4kI8cTTVfkv+9ePP0ieNCCCHEZtjUYEesrugXGSmOEJqtUQna6MWyh7oZoC4GqnXlEmt8rzZpkVIhhBCiHQl2tqgvP/NlADJe5gxHnnvGGPLf//7yrRgTRl/aIlQ26MbwldQUFEIIsYVs2dlYIlKot08KPq9tuPtutNHMhgv1dBwMGjBoE2JQUW9Oo0dHGbOu2WYXst+UxymEEBcy6dkRZ1Q7cJDR0mjztlYpTGN4zVhRno5RKhrVCqo4RaiFNeJOfDOae94cOfLfABgaehuJxOZX4RZCCNGe9OycZ6HeGjk4a2X0wnTyGYiv3naz8FYKatEUdHOmAoQXtkrlRPP7sbHVZ9cJIYTYfBLsnGcH5w5udhPWpfL44wBoE2LvXloscNkyHktv6xC9RRKrz5VqTVZ2F0KIC4UEO+fZC13t/Hyr7n8agKDRI2XajXwuz1sxmuAir7UT8/o3uwlCCCHWSIKd88xwYSe0ahJttytl02nHmrcPzz17vpq0SS7s11EIIX6TSLBzATPmPMzxXr7qfJtDHKPosOLYC0NZFlRKz5z7tm2iIFyyArySYopCCLGVSbBznm3UVOVqUKVUOrQh51qb1dtt+XWOq07KgYqOCkPqQfm8tWwzTE/9ZMktCXaEEGIrk2DnPNuoYawjuSNofR7yYhaCM906u8os/XxX8Ov0VdS1oR5aEPqMjB05923bMmRISwghtjIJds4zS23MUx6aoFnr5pxaGCpr93m+JOLxG6u0hzralpk7ea5btqkSiZ2LN6SwoBBCbGkS7Jxn29LbNuQ8xtCoYnxumVA3eqMWP9AVFo7lohTYWCRViqxu/cDX2j3nbdtMS+vsCCGE2Nok2LlgmXOeoGy0RpcWaussBjMxK4ZC4SqPuBXNzuoO/Zb7hvWOc9q2zWZ0SH1kBF2/uKfYCyHExUCCnQuWWhxiAu4fuZ8fHvvhhq7VFM7PL95oLAtRtFPLWwEKTsb6qJvYkpDo4h7a8Z86ij8yQuXxJza7KUIIIc5A1sY6z9R6Z+4YcPz2MWkYLlY0fnLqSQBmB2bpSfScdfuW0uUlM6rs6J+K076YnkHhGw+bBFAkXp3ekDZsVaoYwMU9UieEEBcN6dnZ4rYf6+TSA73gb8MYQ9jIjamFNabnHwXgudnnmseXN2jKtzGG3Le+DcBcdQ6ViIapLHWm+NjCAI4pnuG4C5wrPzpCCHGhkN/YW1yq6EX/FmKMzFcYy1Wo+NEsrFOFaMbTPSfuaR7/vcPf25DrVp9ZLAp4eP4wxo+6MRy1+krmSllRD0+o8LPJDR1S22qM1ZovdTE/ViGEuNBJsHOBCJfMdpopRkmxgQ4ZL42fk+v5J0+13Lay+dM0LurtUYBeGNvRF/7SGKdjrOWP7TxUsxZCCHFWJNi5QIRteg600Xzz0DdXbN+QXgarNbdIpUs4Ksmsk1l5bLEHVUvi5XajdJTc40yYi7q3Qy9b6FQvK7oohBBi65Bg5zxTZ7mO0mzRX7FttZ6TX43/6qyusSCcn6d24CAQVWpeELMGeC65HVi2QIK2UfkenInLqI/0ogAVr120PTtBLocxra+HMRLsCCHEViXBzgWibS/JKj0nj048etpzncif4N4T9+KHKwMogMKPf9z8fqYys7hjSaC2/MpKWcwm4jidjcRkK2S2OnvadlyoZr/0d1H16moOtI/BnJ9q1kIIIc6KBDsXiEw9RixsnQlV9EurHA0HZg+03W6M4Z+O/BPPzj7LY5OPtT3GH1s9DygKupaEOsoCy8ZSDk8P9GJnKtFeY3ho9MFVz3Mh01YAlVmozkNxAlOtEoYX+ewzIYS4gEmwcwEZLqeX3Dr9ENFPTvyEv33yb5mrzrVs/9HxHzW/z9dPk3RMlBPUTkvlZsvCtj0UiplUimAuS6AtQGGHudOe/0JkwhCjAvAr0QYdgtaUy0c3t2FCCCFWJcHOebaepF23Zq/YZjUW36z6Z579E+iAbxz8Rsu2w/OHm9+vFsy0O9bCbYZXoVr9MdQn+hbvc/jUqsddqEythlG6pXo1ShGPb8yaZ0IIITaeBDtb2CUHV1ZC7qjHgLUHTb72ma5MM12ZXjG0VagXTnvf0rJhMt1IS9anybFWjofBBl3HPPzUmtp4Iak+80wU7Cxh/Po5X6dMCCHE2ZPlIi5Q65nn9M9H/7ltYDNZnmSuOkdXvKvt/fSypFu9ylIXC7OuDFCKxYgRg6BItiO2jlZeGKrPPtfo2VmyMfQxSIKyEEJsVdKzc4E5m4nrp+vB+ceD/9h2u699wmW9FU+lLml7rGm0zGBz/669OI0lJYqZY2fR2q0tnJ9fGdiEoczGEkKILUyCnQucMu2nj69VoAPGS+M8Pvl4y9BY0V85u+hQfLjxXWu/Ul1FNWaUcqgrC6Uu7rfV8mEsf2Jc6uwIIcQWdnF/Km1BG11oL+W/8FlA3zz0TR4YfYCDcwfPeKxpM/Jpm+httNjr5DRrAJ0pCfpCk7j2mijYsZY8D8ZQrY5sXqOEEEKclgQ7F7hYML1h55quLJ7r+bnnm99b/UuvoVYN14xSpOwM4ZIDnp15dsPatxWE+QJ1L9dSYNHOZnDs9GnuJYQQYjNJsLNFxUtu2+2pYOX2TC6GV105TX29wkbeyfIcH5UqYa0pl13hWXGCJcNYPzt6DyfzJy+adbLqx46hjIKl1adDfdEujSGEEBcDCXa2qFTRa7vd1a1BjVu3GD6RZc+hldPUz8YTU0/w3OxzixuURmERM52Lm5alSfuqNV+lNjLQ/H7gFwf43pHv8dknPrsh7dsKTGOFc6feCDxNiNEvLHdKCCHEuSNTz7co119bT40TvvAenQVHc0cp+SVSN19K3y8bBQWVwSVNuCTAsaA5H0kB4bKE3dBenJkUnzp9LZ8LkVFRYJOaS6NtTfWSEG3qm9wqIYQQq5GeHdG0UESw2tfRst01KU55q/ccaTTGcwi9OCjFcWv34k6v1kxWvliGsgyN2WdaobQCo6VnRwghtjAJdrao06zIgKPbv2yxigMbNPnJD0Jq9QCVLgMw6q4e7IRKRwm7VtSuka7GMFatgNUxz8DPo2Gxur44ej/qbrSmWDPYCUO0BDtCCLFlSbBzjgX1kMO/niQ3FQUNa+3d6JiPr7qvt5pckQ5rgO79HWQPp86ypUsoyJXKsPMYqnumscmwMLn8TI8gn8w0GqVR8TkSE1Fw8OTUky+8bVtB4zUMvACjDMH0LJXKiU1ulBBCiNVIsHOOnXpujplTRQ48NL5h57RQlOtRXowdLCwMGpKr+PhjG/OSej3RkJZeEtkY3BUlnF86MopvwpZCexZ223o8U+WpDWnbZjHBQiJ29KTESnGUURh9cdUSEkKIi40EO+dYrXIuKusaan6IW7eIV1yIPUuoF6+j9QvLjTFLIhrfD5dsX/l28UwtOk6FLERCjnKWHNtYTCIISbkb0OvUhh/6HJk/wg+O/aClVtBGCyYmoinmjZ4dSyvcmoudXr0XTgghxOaTYOcCZIimoGfnE9EG7xRW7GRz//HZ8gZcpLHCuTb4oeZ4rG/FIbfM7Qcr6tWoqcWclcFilZbROjvAKdV4eubpF96uNj731Of4wbEfcGT+CF8/8PVzcg0A4/uAweggCuGMwiiDCRvPQe3C7rkSQoiLlQQ7F4olGcuWUQyXWyv2OsnDze+nCtUXeC1wMovnmLeSRB0ai224unSYTj8PxorugGlWFe40cWr5hRo0BqsrR3J07oW1aRUPjD5wTs7bjtEG36owVjjBWFBi2m8EdWHU++UH8+etLUIIIdZOgp3zbCMq7XraxjKKerg8VyS6vWLzOhljsOOLPTU5ZyGwWhzeygZFlDKwpMhhfyX60D/ZkSacj4IdV9moTJGu/adeWKPayNfzPD75+IrtR+aPbPi1IFrxfMx+rpmhfdzPU6xoTBgNIdqWDGcJIcRWJMHOOVbK1TbmRAbswMYKF1+yih9iol1U/BBlRVO7HW2R9I+TqT0LZ7EQp/9Qa7BwJD6IXqiVg+L64lN0B/ko9LEWzz8VXwx8ts110Wsn6HNTeLYH3sZPO//KM19pu/0Hx36w4dcCKP7ifqbrE0u2KEo6gGpUOHE+9+g5ua4QQogXRoKdcyyohWc+aA3s0MbxHdx669pY9VBTC6JrxJJR78m+okPCH8EL5/DCWQCsQJHOx844b9wEIal0a+6JRmHMwjIJin5/5ZCUIVoIdIFnbDxlgTF0xruweqN2LBQuXIvD84eZrc623Rfq0z+v9XDjg6uyX27mMi0YD0uYUGN0iGOfmwRsIYQQL4wEO+fRoYcnznzQKtQqhQSDUFMLot4VLxklKe/2jjb3W43ZUpc918e241mu2N9/2uvow1MkU63BjFbW6jHSkh07Sou9PJMLsUhYx0KhvDpozYHZAxhjyNVynMifYHb0KEZr/GVF+T7z+Gf44bEfcudzdxLolTPa8vX8aR/HeoKqtXokPoZKrTyvLjoE09N43sokbiGEEJtP1sY6h/xlvTpz4yUSV7Rf4POMVimpHLSZZq7sOpnRBMXBCin/OE6gUKYf0ODMoLSPsVaunm7pKun0MVgSRygsNBZLagq2cI1msFigQ8V5US7LSKPQ8rF4imtP9jG7YwqCGiiDFWgeGnsIgIfGHqLj4BjdT5yguLuX6Zsu5ZbhW7iu/zr0sqG3v33yb3n/de9v3i7UC3ztua+d9umqBi8wSXuZQr1AcmQO9qzcN6YK7DGa+flfks1et6HXFUII8cJJz845dOzJDaz5smT45HRLSSyoBiGJ+SiwGpyZQAPPpgrMJA+xa3JZJWMTgjGk/cN4TmvPRczKNKonr+7KmSmunpkm71jNeMhze/Cq0fWtoJG31Mj7eWjsITCG7ieiqsPpY9HztDCzKjQrh6gWChLmajm+/MyXm9tVENL5zAi7//GXXP7gYhL0IxOPnLbN6/UPB/5h5UYr+ltBxTSWqRKGGxtgCSGE2BgS7JxDc+MrhzzOZi1MA7j+0k64Nl0sbfjFKDCyA4ujrsczCc1PvauIVR16Kg+S9I+RrB+jp/JL0v5hbFNtTh9fvJJiZ23yjNdSKFCLdy+mV66l5c0VAcg+N8rub/yq7XkqQYXvPv/dFdv/8eA/AvD3z/59y/bOp0fYfnCOK7qvYGcpgTcbXeNk4eSKc5wtX/srcoDMrAeqkZAdKnS1smHXE0IIsbEk2LkQVJxowcmz0JGLpkMX4qMAzdlbGEPCHyURRNtjwSSWXjlzzMLm+cRw8/aVlZGW/XbjLWQwUcDTcHDbizB4dI52L1yR/tEHQRu6nloZiMTHcwB8Yf8XmCi3z206mV95v6Ej81zVczUdXgehVaXr6WPNfbVwY2bC3fncnVGU2lgSI2k5mLIDVhTshKeSFA7ux7JiG3I9IYQQG0uCnfPtbMrs1FtfpqXTz1dqHQIq5zUaQ94tY4BaoMlXfUzYJtenTdtcK0HV8ljoTUqG9eb3lmURNmr7FKlFdQUb+xSKUF1D3KSgViAe+rjlEXZ/7d62rc4cO3P14e8d+d6KbUPpYYrJk4z3PUh96AjJ7MHmvnbB0XoV60UK9QIq0M1p9t2xJKbgQKwjOihQzARlzu7FFUIIca5t6WDnjjvuQCnV8jU4ONjcb4zhjjvuYHh4mEQiwatf/WqefvrcLEmwUfRZLBoZLKsS6Pir55Xbbm7FtscZYsrKNGvlAMRGFnshlIGumQTd08m2AU90N8Xphs8Co6nYS4omKkWARVHdiEHhhI3ZVpWZxTspjUpUwA5InZxZedIzsOrRLK1iKsrVsZSFMgZloiGnHx3/0brPuZQxhi898yUAUqdmUKkKi5WiVbNnh3BhaY06pk2+kRBCiM21pYMdgBe96EWMjY01v5566qnmvr/4i7/gU5/6FJ/+9Kd5+OGHGRwc5PWvfz2FQmETW7zx5sv+yo2rdCJ48ZVDQAecaBjKDxcKA0JeJTAGeidT9EylsEMLZRR2m16jtVZ9riifjmo0dOQAs45LScWpmYHFHp/OxdwXe8co1uAkQ1f6EF9M7u18ZoTss9Fw2UsGX7Lq9XoePQqqNbhQfkjCH1nlHuvz6MRikUAvV8HqmcVVDijQJkbZ30loklHOjhM9vpmZn23ItYUQQmycLR/sOI7D4OBg86uvL6plYozhr//6r/nTP/1T3va2t7Fv3z7+7u/+jnK5zFe/+tVNbvXq9NlkKC8TFnZih3bbfbbXpuDfskv+LHEN9yWv5bn65VTbVR9odOCEWPyg58aFs5yxXZX6CY6nQGPwbQs8B6UUicPXNfuErKFGIq/SYIdYKlpbyx6awDI1vNkinU+fomv/KZQfclXPVateL3VqlvzgUy3behO9oBbf1jOVmbOahn4yf5JfjS8mUXccGgegJ9YJQMlcRS3sY7zvFkBhBYawVqBaHV33tYQQQpxbWz7YOXToEMPDw+zZs4d/9a/+FUeOREsZHD16lPHxcW677bbmsbFYjFe96lU88MDpF4es1Wrk8/mWr/MlYSdabpuahSnZ65qlFeR3o8xqQ0orty8/dcFKAjDmD/L92HWEqwxPPd7xYuad5LJznT5RWimoWNHw0kKxw3jnsplZiQqqI+p9izvxZpO9YIbhnywOQ27/4RM41ulLQRlAG810YZ5yvYpnxzAsBoL/cOAfmkNRa3Uif6JtftBwajtWcQKlLQIy0cYlxR6L86dIpS5b17WEEEKce1s62Ln55pv50pe+xA9/+EM+97nPMT4+zi233MLMzAzj49Ff2gMDAy33GRgYaO5bzSc/+Umy2Wzza8eOHefsMSzXHe9ufm+KDjzZDc90wViC1dI91PIAw6hVO1rqlW1rbovdyDWpsVhgUDVWMQ+xOOUNtgZha1xny28k8gaNIbFaYIipxQDEHpzE6p5fvGbj36EHnmhtX8Vf+dgbvPnFaf3FagU6sxQq0bY9unVF+EAHbaswt2OM4Z+O/NOK7TcM3NCcjZXOdSzuaOTt6JkY07UcWkutHSGE2Gq2dLBz++238/a3v51rrrmG173udXz/+98H4O/+7u+ax6hldWGMMSu2Lffxj3+cXC7X/Dp5cuNqsqxF3Gmsjj2zZKrySAoe68VMtU5fNlrh1lZWO16N0e17QqrBykClXbyUqUQ9T0UnvWx/9FZRS6OfNtnMS3fX/cV290x24zTWylrKv3Q7zdldqSW5Vl4dlCaYaj9Lq2v/KVAa13YJdYhKJDDVOMYY+mork53/9sm/bXue5aYqK683UPHQThV0gJOJN5buaEy5T/dGBxnI5U6Qyz2+pusIIYQ4f7Z0sLNcKpXimmuu4dChQ81ZWct7cSYnJ1f09iwXi8Xo6Oho+TpvzjRcdSzTeru+vpco0XFgzcfWQ72iOVZjWObR7G+tci/N6R9E+32JfJquJXVoPDuqrtzfs2tl3028ir1tDGfPKfJf/wYdB8ewK4uJzdlnR0iMzWP1zOEoB6Wiys3KKxOGPnp0nM4jh1a04esHvr5qq6tBlSPzR/jGwW+s2Hd7/IbmjC+3J40pLA7L+R3JqASPp3GLAcYYtN74RUiFEEKcvQtqbaxarcazzz7LK17xCvbs2cPg4CB33303119/PQD1ep377ruPP//zP9/klp7eakMzSxmAeQ98i+W1czaKMVFezT9515Ai4A31p5rZLmU7CW3W3QrPEK05BvwlD2+h2KAxaToKaewOBVYMy+vAKItsZhezav/iHZTBHoh6VwaSA1CC7idONJeWiNmxZrFAu6MMJoPXGyeY2E29dIBiUKSzbw8vmYefzpeody6uRD5dmeaB0Qe4vv96jswf4eDcQXZ17GK8NM6x/LG2j+cPr/5DSv+/v6PaNwPVEuBxMHcphfJhlD9H2rscTQIr7xPPVciP/JJ8z8vp7Lyx7fmEEEKcf1u6Z+ejH/0o9913H0ePHuWXv/wlv/d7v0c+n+fd7343Sik+/OEP84lPfIJvfetb7N+/n/e85z0kk0ne9a53bXbTV7XmPGTfgrLTCHZWWkvAtOZLhYaycnnOHkIbRUD7mV7QskQXmJVtu35qutmye3b2UfWj4bPEtbvp9XdgOw5WvQSFMbzpebb3/kvilcU8Jnv3CbA0lrKwlE2u42DL+TsWCvk18meo5gjKOdTMKJZym89vJTnJH25/64r2PT75OF/Y/wXuO3UfY6UxHhp7aNVAByDjLelpq+YItM1kMerlCZQhPHmQKi+L8q+0IV+dY3b2F6ueTwghxPm3pXt2Tp06xR/8wR8wPT1NX18fL33pS3nooYfYtWsXAB/72MeoVCq8//3vZ25ujptvvpkf/ehHZDKZM5x5E6112tUGFeMN1xjPGmN4xh7kudQAZVPAKbdfamFprFOd2r1i8lfcj4ZwlGUxm4gzYdvsxJCfHWL7LTajp44RBiHZiS56t12GevDT9Jc0x+Lt21WLz6JSPqaUxBqcpJ7KweEO7N0nAQsd+gQBuIAOAurO4hNXfuwx3vd77+NzT35uTc/Bcv/26n+LCUMMi/lOlVqU6Bx3POY6MoDPbitOtREFjgclzl+6uxBCiLXY0sHOnXfeedr9SinuuOMO7rjjjvPToA1Qr4Yki52Uzep5HUYDp1sLy1hnWDJiUVmtbb2mhYKDltZLOmxWb0NYS2L8OHjLzmMqhISgLGzb5Z+37eRdRw9jqyh46p0aolSZIZ5PEH/ZEJWJLMmdCerBCbzZJTOsLh2ERjqW1b+4eryxbew90ZCWUoqZQJOoDxCv76A0fRz2zBFFiopc/td0lH+HK7qu4MDc2nOZAP7gyj8g5SSZ/tznmOj7JQulFedORs+nH09jKTsqqJzpgYXqBQYCE1CpnCCR2LmuawohhDg3tvQw1sXo2V+MYh3uhP1dMJlof9BYEmZPE6ToGGFx+5qu57K2KddNBkJfEbgOoWOzopxPGMXHfikb3V42I0spQ2DqjdBAYRonWCimGKvHSc92YOijcHwb9UKa6ngvswO7MbaFsS1yVwyj46vPQOtO9OBaLt1qgKQ3SHrkJXhBJ1YpjXmuDxrTzAvpE8x84QvcuutW3nHFO9b8FPzxi/+YrngX0//9M1RUo0jg/AmCZAwrP0SoFD++5lru3xsVPPQ7ss37piar/HriMU6MfB2zAQUkhRBCvHAS7GxFU6uM6SwRzK+teJ1a5weuti2SxPEtReCsfHvo0SspTeyhOjcUbXDbD3dV1GKQpUOHcj1KsjYGDBbaumRJIxVvrvSS3hYjtzuNsS20lSR2WfvHGLfj9Di7sRMpQGGFUfdSZvgS8O2WekATfQ9ROXyQ3kQv/+rKf3XGx/++a9+HUgoTBGgVkOt4noUxRRUboKt2BSa9nVApDDAfi7ekVbmlAHTA45OP8z8e/79bAh5jDM/NPsevxn4lgZAQQpxHW3oY60KX7UuQm6qs6z6O5RCwhqnLq1ZQ3hhRv0ybaszapV7ubQRRIapNrZ10rUI9sVjYb96K062LlMa7ANBq94r7ZE2SPepFnKo8jKq9iO7cJVjXFYhfcw3V50sEKY/ERB4C0NUkyoZKJSR9/GXNc6TUTvzL5qgVniXWuZg58/zD/y+u2vU/6Axj/Pu97yaIu/zPJz4H1srH51ou5UcfpfTAg0z2PdzybFgjlwMwPbAHlMHogCcGt3Gj7iGYGcCQQ2uDDgMsy6W78jB//6sP4Cd/i0rY+po+MvEIt++5nYyXoTve3Vg248IWzs8z/41vkH3LW3B6eze7OUII0STBzjkU+Otf4TztpZmvzrfZc357Aow5XcbO6VnGsLS9R7IpuvNF5ic8vPoujEo2L1KrhziORWWiF3egyGx1mCtG+rCdKeon67h7Oqj2dUAtT3EoSSK1C/dkEYD0/pXTu5VlMfdElsFX6pY1sp79xr8nU9pBsrwNhWL3eBTI5PcOEiQ9VKjp2n+SyZ+H5DNHqPRNLp5Uhzj9negn+6mhONbVgaGMJsRoQzEsEXOS+EFUt8g9fJzwyisAhRvm8auHwV2ZtvzPR/8ZgH29+3jl9lee5bO9dcx++SsEdpVnf/wfuPytnyIWO329KyGEOF8u/D8nt7DSfPshntNZ6E1ZWHLhXLC0wgns06yvtTbuGu6vlOJAd4aKTjExXaJc68A0/js1mmdqusTYeIFawUNrxRUjN2F8QzgV4FfK0Un8CuVCSM+J7cSPz2CMoVptn4tkh0niA32QOwl+qWVfIXWSib6H8O0S1tAEVv8UHUdP0f3ECboOHsHecyIa9oovDXRsTH6e6uGoltOpZJzQsvCUg3JcQm0IQ83Mb+1uhnexgg9LFh9N+idXXWpDmYCxE3/LV375fk4VTl2ww1u/GPkFD48/zOHUvQCcGvnaJrdICCEWSc/ORa5dOLJQJdkOLQJn9YKFnvawjNUoDBjxVbBkAtbys0e3l+YJWZZLGNY5kO3husIJ5v0A3ejx8hbr/TE2UaDLugRjZtCzIbarqEyPUn9kGjKTxOuDUBnAJOYplOooAwsp3AZDPdA4tkW6dim55FPEd/ZQPTEN2XgUeLjJZvtmup9EFaNgxE6VT/v86Qq4vTuwx6OK3T8bHqZUD1BODM+yqPhlHgxDrijupKtxhTQe3pNHqOzcTpBOEsZdeioPMZu4EUeX8K0OUDZOmKdv8lcECRfXy/Pd578TraQKvPOKd+JYDkdzR7m089LWej+nYYzhJyd+QsyO8Yrtr1jTfV6oX4z8gifHHmMXUPJLlPwSg/O717R0ixBCnA8S7JxDyWyMcm79vTtro1BGYdrkzJz+XmtnaQUKjLKbAUzOqbEQo3QYiyIhsXiJWnUxctk+P8PzqX4AXCcKdp7sS3NdYfkVIgtVlgH0ZCP4avQaheUanaofp7gdjEKHhsbiEM37V31NVdtYgU/cjQI5K+bidqcx4xMEng+JTohlWSsTupjQJTETp9d/CWNEjdeWi8HHqMWg7qgbcIOOhmxi2NiNtiVOnIJ4dE3j2KhLf4WxLcAQmyuRGJtvXq+4p58u9Si5+DUoE/Kjx/8jRe8yfLuTB0Yf4O17305/sr8leHh6+mnuO3UfANlYlndd+S7y9TwH56JCjLcM34JtrV4g8mws9DwttMMYwxNTT7DjB62LuJ58/jEKHV/k5Zf9uw29vhBCnA0Jds6hnuHUOQx2wKt51OLrO78drOHDT7nYwZK3xioRUo92GMVfkaTcVS7SW6qgUx0Ye9lyokkPk69i9e2AYJZaGDarLJuZpb0sixe1CjbhfIjCEMRDHLXYtkBrKgE80bWNuZTh1aPHqfkB1ZpPvDeNdcgiPdtPNauZv9xAvQj1EmAaeceL11kMJAzGd+kbeQ2qMM5YOQp09mfS1GuaugpQOBhl4eHgE7Kney/1vIeLhWUU9sFOgqESqjGxrsNKog6M4mcTJIsBfuhHO3QAfpn0Ec38i3YyeOqnWKGm0tdBR+0ZZhIvA6X434f+N67lsiOzgyO5Iytei1wtx2ef+Czb0our3tfCGkkr2f7FWydjDJ/f/3nqyxKtFxKr7YoPscX3opuvMDL5E57rfhlXdl+5IW0QQoizJTk7F7INSO9YGqcoEw1tKSyM5eCp06+2rlAk7dbgKaFcFHD9xCQhGuMGzIZRUcCaZVHwNVZnAjuTpuKHVHzNWDJOxbaYzddazr6cKWo8ZRMFKtH+WqD56iV72d+dZKRzkCOZDLOFkJmZWuMM0QOM5yxSJ8pQnoWgBrUi1PKNwAc63BR9xkJVi/Q8btP/9JWo+THmliSZP9Q5QKCX5N5YNg42KHh+soifHEI1+qhe5PWgTyWhFgVKnh0Nurm5Ct3xbvpTAwynhxnW0KFcqBWIzxRITOSITRfofHYEjCFTf655OV/7bQOdpUaKI83vv/j0F/nhsR+e9vi18EOfzz7x2RWBDoA2ulkV3B4eX7H/nhP38OjEoy+4DUII8UJIz86F6gzJwXZgY2mLunv6iMgObQygnRA7XMuQR+v5Olyb8pK0H2tJT4nrVVlaYvmnwwO84dQYxVpIRhsKKsWv+z2OZaJp6r93+GhjkjdoDX6ocRamhzeiMqOhpjWusgmNoYqLUY12a4sT6SS35l+MFdTRoU/3yy6jSw8S5CroBw9Q6oD4jm44ehKA4qCLSvVwaSzBJfoqZr7/JIF1HQCBMYQxD6vxqDV28/En/ICy40TDfBim83nsq19KunSMoUPP4pioTXrSxerKo7wshD7YLqpWxDYhuNHQX9pySVkuczM1bC9NqR7NNut8doT5qxVuOIdvd63htVnp8PxhPvP4Z5q3f2fP77AtvQ3XdtecU/O5p06/3Eb66BSni7x/OfZLbhi4Yc1tFkKIjSbBzkUqHrpoA3a42BNhr7LEhGJtw1umlgT8ZRtXnmtBwQR0KI+YYzGt8wS2TcW2SISakfkK5Z7LOJ7xMbqMUiFV2yLUBstS/HR7kiu8fi6pTTT6H6MLLfSshIUO8rWA7++6rHGtKh10Mu5lgAmMMdRzaUy3QdkWbneKrt++gkLcx4o5lPvjWL4miNuQ9lC1arQ6OzGq2jDva+ykh+1FPyLlmtOyCPxr5vLMkOShxlM6VT2KVf9dSskZdvR9j57f6qT8YI7kFITTMbo9mwnfwb6sAHE/eqZqRVJzaUpdRRTQHe8BIOWmKNaL+NpnX+8+9k/vZyZ5yxlfn7W46+hdK7bduvNWLuu8jInyBI7l8I2D36Ar3kXaTXOycPKM5+x99CgqHfWQ9Sb7yNdyjSDK4Iaz+HY3+6f3s69334Y8BiGEWC8Jdi5YUVgRq8aoxWorRn0sSzUSZaPgwNJqXVPNreUn1A4UemguWAWn7RVQyhAaHfUeEPV+VHSFpzu7uHFmhqJj8eOeBDE/xBgHpUImEgk6ixVG0mnmu1M8qi7jktpEFAAtb9/0Lh7t7SZvRUNtVeo01kNnNJGgL9SEoaZ+cg9mRx2lwOtMoYyDMYp6eslbP3cKFR/AAKHaxXy98ZzFFo/5aX8PvjboRtCVijv0WoaHGs/TWNplaDJAb0uCY2N5DpMvjnpj7GrIdfVB+NUs4aEMfbE+3Eaui5NJkDkUFZ7Ue26i5s1RTo7hNK4dt+O8qPdF/LxUx6jWhchev+v17MnuwbGiYx8YeYDHpx5f9TVZzU9O/ISfnPhJy7a56hxz1bkVx75x9xsZSg9x74l7o9XitUZlili9MwBkbnwJO37oMdH3K6ZCQ6Z+kNnES/nZqZ8Rs2Ps7dq77vYJIcQLJcHOptjA6bgGbG0R2q11XJZWP1Zmcbr5Rmn3CMyyf6+bmeSxvkE6UlnyVYXnuhywHW6cmeHu7V3Nc9hODKPrPNrXy62lOaY6ajgmu2TCO/ha46sCMSBULqHVyYFsd3PtLYCyrUg6Ke4Z3M6/PrUPv6NMLN1HZSZPPFtGOSFBIUXoO/QGNr5To+5UMRiqlQzPPd1Jrb74I6GWFCUcyXSAhqqqk/QDLLUwZKdImhiFuA2FMlWnl3KsD5asSRbGbdy+To69Llpi47WZqyn88/7mfrc3gz9dwDr6IAmgPjiPP5QGJ0754YdJveQlvCELu3b/EUqpVast37LtFl42/DL+1/7/RS3c+MT4V2x7BZd0Rst8/M4lvxM9Lz/9Aft7v9E8Rtk2iqiXcF8wyJP2Ys2iu4/fTcbLMJga3PC2CSHE6UiC8sVgWY/N0qRjJ3DWmIvTavlSESbf3Xp71RuLgdBwucQtE6PULQsrNYRlR4HEnZfuRoUGZcC3k4SWR90kqKgU37ykn0f6NJVSFmMsjroDGAd0SvHYzmcBouOtNKFp7ekoOQpjxzFYmFqaYGaA0bECR5+2KBzfRv7wTkJ/MZhx6h6JmQzJmQ7yeR+jWyZnAVB35ig70wQLxR5VSKZWh0yMzkQW143OZymFHnkA8+wDPN19G3TvaTlPSrn0OUkGnCSxpdPBFXS+9NJlz76B4gQUxyGsE0xNAXD82KeZmbkXYwxat19SRCnFq3e8uu2+1cSmCwz/eD+x6VVqAxCtAn9N3zUrtvuPLU45z10xTHfPq5q3g4mJxsNZDMS/eeib62qbEEJsBOnZuVAoqFNHE0JLn8dK1pLg5mz7kJK4LAyBARA0SvitUgkYwHMsCMC2FJaCmGuRxqeiA1jy+R6GDliNhGNlEaoYEA3lzGkbU93V3PfLzJV06hQ6NUOssvBoFN/e1tM8n2MpWCjPY9uAxbibYdgvUAs0ccdGNxJugkBTrvho3f5x2JkEYamGnfSouhPUnEnK5W2ESxJ2rpqfo5aMo2IKNx7Hr/m4lk0Ml0qlQPnxn8F/+hAc+U7zPhbwe6koqFlzob2gBoUxakc9wlKR2O495MZ/RX72cZTT+qM7OPhm8vkn6ey8iV3pfv7tVe/kq/s/R2Bl6En08s4r39k89nNPfg5fL+ZeDd37TPTvT5/h2O/dvKIZ773mvcTsWPO21j6Tk/9MsjBIuWMxp8fYFpn0tYzUH4GJa2HgSTCGWDhFzVlcOuIzj3+G91/3/rU9B0IIsQEk2LmA1BsLhPqUSRKnqjRxY2GHNuGSSsiO72zyK2twbYuYA8XTBEdLWUoRGtPSS6WUjcFwMNOPH/axrzqOAX6YvhYzHwVyrm2xdIWFuqWIx7Lcu83nXx+Lgh3tZRgdywNQVTa4fiOPqE07HBsrm6TmTFNzoyGY73ZFvTQlVUNj0JSwYhY7O4d4ydQhfqoUGENXYhsqP065w/Dg//4aZvh6mDtJ0u+jWns1rvoVVuzMw0sGQ3xHD9WTM81tweQUweRU83biuuswlTImDLFSKY4/9N9wevuYe+anKMfB276dbG0/vp3BcS4jCEo4TgqtAy53pjhU9smmL+P6/muZjB1gvjZPh9fBH7/4j6NV343hVPEUaTfdEugAnDr1ZYKgwNSj/4Cf9KFRHmm6/moeu+s4dXYTTs+T7d1PzNegDrcEO0BzhtilnZcynBpmX+8+qbYshDhnJNg5h1abjNuX7GWyPLnK3lZBuPIsefIkiVO0AuKhh9Jb7UMimte0dDBMG/90d0Cp1qRoA2g7GqbyaiFaK57w/gXziaA51dxzonv4RjM4n2N7cZwnhgaINz4092e7eVFulukwSdqv0OlqvPmdFLqfwzE2NRUsmSrfeJ4zg/TEKpwsucwWTzGmbYrbPDwgUCEvGZtAK41l2cSdGBljwPIgrPHrgTS3nujFVGw6TiXpO2zo9KMZSCdTc1j6EvL+T1DGIVHV1CyP7YM30vWi18E/Pd7yfNgJF2VbmFCTOjpDqasYLWya7gc7RuXx1uOBlmDIHx2lszhCaWcvnhVy4sT/bO7bFkuQpEqHM4Y1P83uviHqbhpLO0S9eTZKKXZkFhcv9f15Tp78u+iZajNlvXDpADyfgX5F/PK9lH71MKFRXGb6KGZT3JAd4EfTEyvafHj+MIfnDxN34uzt2osxhnw9j6WiZUo6vI4V9xFCiPWSYGcTJJ0ku7K7OJ47fsZj9WoLQ27R9SKz/Ulqpybx3BBwmksqhOHSfJDWD8rLCiHPxQO00mi1MESnqDkKrQEDjh9D11KYqo3rZfDdEGVsagQUrBqppAZdwHGTeJ195McDnujq5rGBQQYrAS+dhJquofJJlFvBK9tU+w9EvUlAXWtKXZeT6h/m8NPPkaPG4Wovj16+GyeEsPGEp8MCgYJLhi8HDTvSfbjlPL6KM9vaAUKn39m6wXbpsG4DY6inxnGBZ4/MY5c7UE4KFSwsXKowRpG4pJ/yoXEy01lSMxkmLxuDwjgkuqK1vqwz//imTkzjjeQpJaJzu8ND+KNjdOzYgTsUzWSb6XqqeXxw9NP09r6GTOYa6vVpqtVTzMz8jGBmmtrhI9jdA2BlCecmGi1VxE0v+epeMAqVPwXVAhiDOvEKjPNT+nbuRtVPcfvuN/PPx/65bTvvPn43A6kBvvLMV1q2v+/a9+Fapy9uKcTZ0LpOsXSQ6aloJuL27f8Gz+s5w73EhUqCnU3iqvZP/fLE4NWt7Tin8Rd4SEvazDnjxW3isWBFoi8srKu0uEOj2T47xnDJ4ZEhH200WjlYKAKvA8/KNSr0gkWWmKOpUiZQMQIV4oUuJaJKyZal6ErHUAqUZZHu287oyJFoans8ScVSJLQHyoO56zG6iLEOYJQidBOUTR+1iST7wxy/vrSfeZWiUk3j+hVsy6JsVbGUiq6rbJKJFJQCrk71EgtLBGVNyYOcZ5Mth9QT7VdlR1nNp6Dqh9hk2f+lB+g2NxNYI/T3etSdMYLJEun+YvNullkyl6Ayx+CTSeZ22VS7bZQqQr2IinWhlE0sn6LSkVu85JIXwx8dA6B+8iT1kydJXPfi1tcIw9T0PUxN3I2yHfzpaWqHTmICD0ihx4pA1C7LU1DPoP082Qd2kfDnMEMVlKXA9ylUOogB1WeeIfGiF2Fmv8ul2Ss4vEoV6OWBDkT5RQBvveyt9CZ7OZo7yuOTj3Pz0M3s6tjVcmw9rFOoF/j+ke9z4+CNXN1zNX7o49oSLImVZmZ+SqHwbPO21uduaR+x+STY2SwvcOTJLOvamYqXqVshQ+V0y3a7UYE4VAZ7HXV2losGplZ2J2Udj5WLBCy535JLFqmTYLH7o26qxGtVxqyAN47McNfwdgwWdTvN/yOzjaf9B3nIGqZY6SeBC9QAQ6BaV2pXQFfK44qdnbjPz/NYogvbdknHPYo1Hz8o8K3BJLefKnOgK4lB0Xn1taRmH2S45lAwCR5OX4k96FJyARwqroupFanbKVwVQxM2A8esm25OS3dsB8uxotlYxnDv5Xt467EKM3OjmHQU22DAaLMi2vRDDbYV/Qs4ahuzM1AbnIGwRuGUTyzTQ+LKYSrPjQJgcPGNw0RwHaXSCQJnBlcpXMr0H7geO3AwKkvaTOBkhxjNHiHb29rl5AZpUuVh5jsOUnm8dQHP8q8ejq4TOmBsjLbBeGhjCLXGUgrbstBaUywojC7jV/qgEuABZsQnBDw3oA50TLyE/MCvMEajlMVec4DXXft+npp+mpJf4omp1uuv5lvPf6vl9vePfJ/X7nwtx3LH2i6h8dOTP+WnJ3/avP37l/8+fcm+NV1L/GZYGugAGLPKHyjioiDBzlajVnzTwlJgK4W/LAfGCi3qbp02KT4b2Kg2wY7lMRxXHKmuds/W+/hKYxuLqvLZPp8nJCS0FEVT5bePHuVgwiYRq+F1XMYVbolfanBtuznbaqmFAn+WY7GwzkTMGLTROJaNpRSZuEuh6lOKxfn2VQN4BiqWgvkSbvCvSWCwjcVcPUVHDGJLZl1F64QqQrVk2Qqgf+f14Fh4wylQimufD3nYVtQDQ8WUOJ7x2Fk01HM2TkeA425jttpFPeZCsYITlFAVBThRQnZoyFd8OhJRD4QyCmO5OH6G+OEbOa49yOylFHug+RrEu7I46QQm4aExVGqDTPgJlB/DdmG49xJ6ph+iZz4GM7sIk/049QlMogfyI6jSMwzsvBnfqVOJT1FJtYasJlg6+0pTrlVIHL4JbIfiJb+MdoQ+6BD0kmOJCi86voOjAo5MD7KtK0v54UdIveQlABw/9hm6nBTXbv+3dMY7ue/kfe3fPGdwz4l71nzsPx78RwB2dezitl23SW+PWMFxOje7CeIckjo7F4iFXhVLRdO652itbrtQHdmreSvuux4BIYVithlIwMqwa3lyqmstP8LgdhRxM8XmiugJL+rWKNk+OadOzfIZqLd2G8dQ9OZzuGHI82NPki9N8gZ3HM9pH5NfO3IMZVstvUedA0luHD3ebLUC0nGHwf5BQktRsRUo6El5eFYK10pgkwQUwZLzGKNRrsHzFNptjbQsK1r8M/GiXhJX93B1xiI5lKKuoE6Nn3dXKXnRh2mQdyjUNPVQoSohyvYIY13Y7gDaOGjtomqasNF7AuDM7AI/iZW7BuX1Ln/2F18Rs7jNijk4nSm87jR2JsFETTOZuYlq8uXkC32YaQjyA+jZOGFlN6G6Ek48zpEjxzn6yBi9B7fRd/xW+g5fR/fzl2EHCazQozbWhz50JYlnrkXV6qhKNVqpPfTBaFTChcYQW4jmiJvnmFsgxGD7JTqDBNnxYcAQFheH5cKgxLFjnyWR+zED4VEcvXqNn8YLcvr9S45L+CO44Wzb3cfzx/ncU5/j15O/Xtv5xG+EoaG347qSDH8xk56dC4Re1rWxdEhJo0FrnHr0YWtQGOMQV7FmoHK6Aaw6PmBwcNGE6NDDVyGXVCcZjQ0384iW/rvaR88Vt7wS9eOTxOOKpd0xjqXYW5jnSDIbLSVh2Y0xrsUzFa06cS9LvFEs0K8Nk8oV0XYMqOIuGQd6xchJXH+hTYaBjkzUNqWIGUPVrzSPTWb6cO3WZyDh2VRRWEvOWWkcU7cUFjWUFX2A22bxmD4r2fZxv9gKuMtSOKEhwOfru2Ik58rYQcD08AADlseV+ZADHTZ1C5K9WcLQBaV41UiB0Irq+zgqQOFhH7wZx1LUky6xuImSfldQLd8vz/dSKAq2DR0pqqGGRj5TGNRQ9RQ93rVU5x6kN3kz1ZyFr6Op7nWdQk+lCA1EIZtevJbRUW8O0Ywxv7HempXMcCIYI4bFqUyGw47F6yc1QWWGgt/HYLGbcbMfbJv4VVdjp1LNdl7ftb3xXdRbqY1msjJJ1sviWi6PT/2aqCqBw2z8xqgtjQhXmQDTWKq1p/JLLuu6jHytwmQ5Sv6v210UvCtXVIt8cPRBHhx9kD+48g/I1XLszu5u+7r+JpquTHP/yP3cPHgzQ+mhTW1LvT7N1NSP6ep6Kcnk7g07b6l0uOV2IrF9lSPFxUKCnXMoDM5cY8YYg18vYzsetu2umqDcLl/GGB/wKFNG+QEOhtAERLN5QrQJ8ax04/7RB3fI6uPSwbJFPuO6EH2EKjCOA9rHOKcLmxRuLE483v5t1VGv0ehEWSHVGaM+V8Wgmz1HtdI+aiVQ2TraGDKWS0FFj63iF3FJY9lRTRhr2YdZuVbEwmChcLz2AcpyBijbPjE3RkI5lOoLjyo6t4VqLnC53OWE3AVU7ehobdUodXRGO2Md4MOBjihoyrkW9bBC3Z8m7XRw764uLN9n32SeK2eKYLmU641AsRrQ3ZsiGTMYN4muVbAtQ0dfGjudYr7lLdao8hxY+KGF62hsy2CpaDHUBVbCw6/6TNQ0vcmoiOC83/696mTiGNtCEwWsuhbVklYxhzC0CEOLU84kIz0+T2f2YmuNbUUdMR4VXjNRYaqmSBoYfERTuqSXgn4aALszi7dzF1Y83nJNS1kMJheXlLhx4CZKfolnZp6hp/JQc/vC0hUKRcbL4GZvAqAr1tVMXq4GVZ6afrB5n5rTh29lqdl9oBRfe+5rKx7z7+z5HXZ17CII8tT9Il6s/7wPe2mjuffEvQykBs77Aqp3HbmLol/kW89/a0Xxx1KuxuTxAtsu78Rb5ed8I01MfB/fn2d8/Dtccsl/eMHnC8MKc3MPks8vzkAcHHzzCz6v2Pok2DmHxg7Nn/GYciGqjeLXSqQ6+tdxdoUxPj7tlw2AhX4Vg0YTNCovrzyLhWGVDzoTYGgMnTk2gdZnqN0cidlQCyHjKaaA4XKRgp0iQxwsi1BZ4HgoSs37WLZFR1ecSlWR6InT1ZtibiLar70Sftkmb0DF4gQmemRewsGNx0mEim1X7oCxJSt0K6iYaHXx9GmavBBEhmERrWt0JFwyQRE7DEkVCwyWCjzTvxOAOKf/wIuFmpptYVmKmGtRDVRjIVRrIaUIgKRnE/ds6j7kdRGjNN3KY39/Bw/3ugz7HjPpOK88OU9fbBtzddjxok4K9adx3B60Y/OlS66mUkjytuIIjgK/7pPNJkm5SU6M2gRhiaDR69KRXPYeUQo7FScsrUy0crtToA3KiurcGKN4Nn8MO+Nwy74edF1TqnrUAxtjGVTapmB38ysniWdCbMvFxEqYisfTnQleOVnGcuBY/Rou9R4jeWSKlH45WvlMmEeozu7HtRoJ2j3d2Nksdk8vSil0tUqYz+P09JByU9w0eNNpn/924k6cmwZvwmB4ZPwRYsEUMaZI8/yKY7XyKHl7+NHhf4gqT5cfaO7Lx67Et7t51fZXsT2znVpYoyvWRWACnpx6kiu7ryQbyxLqENtafd6j1j612hjx+DaUstE65FjhOJ2xTlKWxrHTzBcP8J2DXwfgsJXBAbLxnsaaYoZy+Rix2AC2naRUOkgs1o/rdrW9XhhWsSwXsAiCeRwn27LmG0AQFAmCPKcqZTJehnJQXnGehSVKnv7ZCADVUo2rXratbc2ljeT78xt0nhz5/JNUqyPUaq31npLJPavc6/TCxiLHy//QEluTBDub5ux+QJaHK7VGsLOwfWHWVWn6KhLhTmZCRf3KeYzRtEvRWm1Iqs+fY7g+ydOpALvxIb/W3Ofrh2wmioa+pOLIBFwzN43RSUpOitBNRVnWQMrKUAwXp0i7jsXO7gSDe7rQS3salAHlgGVheTH656KCjAvTzDs7esn29bcGO4Ab7wCjuenUEY4m4kzEYtQCTcZWzBTyVMM6mXKNK2YLTOzoBaW4qlRmZ7WGDgMKM9F1NBobqyWPqZ195TyPZjoXm+1G687HrBJ5U8YjRqjqKO1ibI32LEIUKE3RqdPpxymZCodiGg+4b0cnMdfhTSMBvzqQIzkcknc00ybGr0cVbizFU36CgaCIwmJ+1mXQ7qBuAtx4HNcKqTaGvwxRb4s2ikrNRQcOMeNjLZnZpmwr6sWyFocrc/WQwMviOL0cOu6R8GyC3hi2URhLUzea+zuuIqy4VNF4sWr0TMUrUE3yvaEEbxmrogOfY/WrGPQC3BGw+xOUDv4OlcAic8U/E3dCgplZgplZOHK05XmtHzuG3dWJOzAYBT/dXSjXo3bsKOHc/KqvR/yqK7EzHc3HshAszVXneH5+ZbBjmTqZ2oG25+qoPQfA/oMP8JjdhW2qFLwrSAQjxIIpjjWaXHGGuX7wZi7t3kcsNgRo8sWDxL0+qv4cudmfYzD42me2MsvJwsm210st+f6Jg9GisT2JbnZ37KEaVkk4iTWVqdDGEBgfRzkotXKoc8FCzxlAr7KY866go/YsR45Evb1erI96bYrA2oNl+pkt/pAjRzoBGB5+B/H4CxvuKlR9tIZscuN70MKwysmTX2y7b3j4HWd1zkAbPnNykoxj8++2Lc+rO7+MMegwwHYk6f50JNjZROYMSZcJJ0E9KGEwhJy+AvHC77DQcgh88Cs9JDyLalg8/f1WcVPxGVRjZs16JYavYnd5hnpusUq0opE2sSSZudPtY8KPgp1omngd11HYlmrpa1ILOblOnJcWSqQCi7LtEE8vJhRmHZswkaCcW+zFiKXiDOXLDO3JYh3NcUml2qgPDJZrc3SuRm+phmMMvzU+Qy0VY3ubYTqtNHV8dhTnl7Rp5XFewuPGWp7xZIqp5qM2uJaDJsSn1qwSXaaOafQCObaFZRR5r4YfKCzboeApQhOSsUK+tMfjpilNvxcFq76lQENQ72HOSfPL1BUEyuZlkw6lyjR4ce4fSFNzOgmtnfR5Hv9ybJpi1WCqeRxVwJg6VRMnqUoYFHUTI51NUfVjeE4epSAXf5ZZv5dYPFrqQQNVpVDKYJTBYHjG7kajMCisTAaHCh2mSr5uU7fhVCZJfayE6zr4NcNk3eD4ZTgGJpZBVU+iD+yiYyfE8jtR85MYNYc/lGW+KwowLGNhTflU56Lb/ugotvawtIOxbdxqN3WnSKij50fZPoMzN8FUQCk5SjEVBRTxK67A6siQtVLcOHgjuZGjTBx7huLOHrS79l+FXhhNDuisPr5iXyIY5blT3+K5U99ase+FmqnMMlNZTLyOOzH80CdhJ+lJ9TBXnWMgOUDGy2Api1KlwrPPHYFUAB2Lvz8822UgOdiy+nyhvpgTFhpNR21xWnZd16lXRpgqT1FXE3i21xI0jY5GvVBKWQwM/C6O04HntS4cfDrGGP7nz6No8f2vuRTCGfwgRzq1d8Wxvp/DGB9vReJ+o+1hDctyyeV/zezM/ae9bumRhylM2BSA3vf/McpeeyWyibpPTWtq9eg31bwfcN9cgZdkUwzFXtgkkfU6+NAvmDl1nOvf+LskMpJkvRoJdrYQrVuTkLvjXcxXS8wxi0eVZQV6W9NTl9TQqSndcsyu2ihHYoNspO66t+Ld0/z8f9Fbo26En3yyZX/Ss3GsKJiJWV1YKiSbcPFsC0sV2d3bhZfJUll6rmWUAceN0dG7B8+1uKVQJJHo4/pMkmeSSWaIgqdLyxWqPZ28IhVjIX5RQHdfknRX9Ezq3BTaVni2zSV7O+lJeUwfzbe9rlGGtB/NHnNj6bbHYDs4OmCvrjFjKzzjgjFYlo1WIftyBUoxj67BGM9VfKgEpOtVcp2Lr6zdCH4SqRR2NaAY5qmHFj8f6CaVXrLqeAkMNk+Ym3BV1C3/zzv34oZVQizsYA6XIsVYB+MqZDYbZycFHFx6cnXwkuwyaY5Un6Kuy1zV/TLsrn4SQG76BOiA0XCIXTuv4MT4FAdch1/1D2Gw2B67kZtqz2I7Nr90roA6hG6I5yb5d711Lhk/xP/JldHQneXw7eEEL50J2VbzqZkYFhpLhehKDpc06VIv3sE5NDm0iRGaQdwj4A1VqWUcYtMJgsQR6OzA2B2gLLpPvh5Uox4QMNv/ADg5sBxM6BLOdwAK2yk0u0mqBw4Qq3eRKm1jrvNJXKXZ7vbDhCJ53fXNxVUrpRwHRx6n3pGgcZEoMXuLVXKuBjWCQkClVqWQzaNci3xtyft3zgPjQNFdDHZ0NCHhZOEkJydHwTHgrp5b+PDowy0TACkniTtx4k4cQxZf+3hW9OFujGZ8/DvrfhyZzIuAHYCiWA3ITUZ5VPWul6w4dqGHpr//jQRhkSAokM+trVbTUsHcLIMTL23env7MZ+n70AfXfP/lv56+NzXPeM3nYKnKf9xzfpO6Z05Fyfjjzx9kz/U3ntdrX0gk2NkiHMvFVMtYS/qv/VBT8zV16iz9W8FqJMmGS3JlKzM7UIMLxdVafxQd0xpEDdRnmTjNX17GWPiVDrz44vT25T0ZqcDB4FPqPQXjbf6SUWrFbGGlFMlY9JYbSse5wigKc4tvQceySCXiVFiDRnMGgoAX6yiIuvzyyynPB6TDYS6xPWqMNo/rGkhRLfmkOhfbalsQc21AMdCZOOMlk9lBhnfuxnaXh52LjxmiwcJXjR6jVgswKGK/PYA5MUtMG7K2odfTXDn6PIeniijbwskXONAzxEwsAY06SqoxmuQ5FjVtCIIZQl1GYaOURRDMobCpKR/TyM6qh/PUjIVlQlwT4hPiBzNYVpxj8SrH4jZgg9mJ0oY9ExMMz+5g//ZexmYDBuuGOReuJo5LlWrvbh7LDjFS8HlyYPH9krNsfpxoJM0uvP+SIX/72y9m9+TPoJbk9kKBb1pZatWA6Y4uvpcOed9sGVspKiaBE7OxLRujDTkdUK0ZrEZ/nh13Cas+5viNZDrKJKsdzG+30bUiNN4dZnahyKIhMFBKzmIlKoCKgttiFADquId2iKo72i4oCy9I0z9xC7rageUVUG4AP4zOZVRI3IrxMvNyfKdIMX2CoPAcbncKd9+rODl/kgkWe0EsP8CqBwSp1iTrM7HqPqlTs/gdCYxlEZ7qZ/aqy8keGsPavp2XvOxtZOMdHJ47xBMnv03SP9H2PLoWPWf1iotrfHQlxE47KFthjNXym2Ce60idmsRNz0Dah7nG+3i43KxTBaCtGJauQahgIhEFQ32L+V3VoEo1qPLI+ChhOUTXNE7GBqO4Zuia5rpmruVSCSqk3BQKxXhpHMdy6E209srk8/sZUD8D4NDhFP2Z6Lmcn/tVy3HT04t1lSYnf7Cu53upjuz1hHetLD2gKxWsxJl/D7Qz57cpBCa2FAl2NtViNNAd78KxHPxgcRimVF/lB6hZZmXx/mHoLXkxTz+Wv/rE8cUjCuNX0bN7cRaLHUtBeWmiq2FKPUkmncawSmL1aZrh2BbekiGtdj0527ovYWS2/dIC7cTjcS7dvZejuWgQaWkVn2TWI5n1Wo4Fxc7YdpJ2gqtecR22bfP3B6PhB8tysL3WX3xWLIUbS7Hc9u3bGR8fx+nox5+O/sq6aufVPH3gcZxYkstVSM/OvRQrdRJuyDxByx/Lrq146dgoVcumUJ0lkxjgsauuoNg4JhWzMbaF59iNoc+QuKuwlcHRqlklOxN3CUOFMmD5Fr6OPgi1XpaIrCwUISe7spzsAvD55bCF7Ua9AvdnPV4+ofhRlwd+EQZOMyRhQeAG9DLGtq4ETEVDSe9Iz3JP5iamZuZRhRxKGU6kA4bqHnHfoE00EKKsKKqr1FOAwVYhjhXH7QhxbE2NDioxQ8lyo5IKjWrTurakrEE2QRiPUbc1obFQGCzHISzVcIvz0NmYgRjW0SUPM/IrfHUtqjGE53TOQLILpRxUUMWKRWUM8rkhnLk+OufnsA4rZipPsN0M86LCiwisKraOEn8L9QIpL03p5dfyxMgj9G3byeiJewjcJOknC7iFxZ+bepgldsk4CbdIJtaJW3bRgWKbfy08CbAHDgGHvkcd2JVKke2/lpOOT230EWrdaYKEx3jvK0mfmGd6RhGkPBzlEcwFULfg2RhuP2QnNPHpedjpM3TNyyg8cIScfwMUFOwuwFyaVOU4PdMPUUtmCPdocskXEdjRUIg5mYK56GdA7RglpufQpR46UvspV3fi2FPMzSboih/Bn4+e46d4kmht3KXvcNjbtbeZn1TXdXriPcTslX801E4zg3XpDKq1SiR3UWmUIQAYHv59Sl/7EZZZOWQ187/+F30f+MC6r7FVtJuxKxZJsLOZWt6bZ042rKmQ5Gov2ZJhLLPke89e3/ixZTTDhYWP2dYe7KoKGik3Cs+psfARGmuMEy0UDlwQsxXdnkfZOOTbz9heYkmhvIVhJ2Wxo+cyLPcgbr8F7evEgd3+uXvFK17Bz3/+cyAKSHK5HFdffTWJRAKlFO7oIVLjJYxr4ywvXKgg3bWdVLyDXVaNGcemu1yG7Mrr7N27l0svvZRf/eDp5rYrf/sGjk1Oke7uwLZtdnf3Yxrlra0buzn1+BOcDArUG0/ZpX4KbRT764Yd8R6cfAE3X+OHQ61/BS/0sLnNqeSt7bZtBcbB1hosB8dzqAWa+hnKIIRGRzNLGtf4xaDXPgKN2+BY0DifcRTa9ekoN3o7FpbRUIordg8zNRcNKxoM/7RnkJuPHaPTCbg6fimWCZnzc6SNi3IsTBCicQi0Iqi3Pq5Au2jlsTAmWYt3N99OpmaolNPoTJlQBdhGMRfG8eIpyo4mIAYoXCvENYa8uZaCbwDDYMzGn+8hP5shDI/SZx9BAYFxGPGjdcOudl1mdT9zj/ZwyfYYJAxO4GAqZYzVTSaeQRnouH8/ryAORye5kn0Q1iGuIOlg6iWq5SpPz6XwwklcE29O3Q5rNoWxk2Q64tRKJUZyKbq64lixAbxqBfv4EfqTz+FnNWrGp+65ZH/xLKaep+r0gNHELYeqXyZQe3BMAFMWSmnqdhc7Rvvo/8ZhglmXnB4j7XUQHlbM10Zw0jn0sIdbqpF4togZm2FmXydsB0ZswMcPfOoH6hRJkawNMF0fABRhvYNqWGWstCQYLoEixO2L4fV4KAJcXeDJYgHH7qRm93CwpnFMlt/f+ybGJ76DCeuYMEBX8/jJXqL6FGfHtuMMDf3eqgt6hvPz6IXiljqk5/94DzNf/BKgQBvC+Xnszs4zXmf5j8Zaa15uWVo3ZnxcvDPLJNg5h278F3t45PtH2+5b7S1VrRVXrWtdV3rVXwOr/awtjKev5doAr8s9zNzsy1a5fqOYnKWIu1Yz2LmsL83heYPjrXw7DScS5LTD0kwYq00Lqv7y+j8Kx3bxnBhup7P66u+A29u+63np0Ft/fz9797YmPGrPpjicRrmrJCaq6BzXVmoYoqHGxXO3HmpZrS9atjfFjquHsexoeI1nF/+6z2Qy9DoO1sJjUuBioVEk/WjmlwJsA7ePTvNcb4bRVBzjNWZLKYgn4+Rnqry8NMu25BM85FzNdCbenFZs6RjVmqZaDoi7NsbQXIMrE3fxawbtq5Yk+YqtSIRm5dtPKaxsFqM0pl4mHXcItaHih9ixFNeXH2TMvgxHOS1PzPt39FOrBzzyyNN4tegD5pe7d+MFivH5cQYDD2VbJCyNSob0+nGU6zBj8tR1iBdA3tEk8IjZZWxrsa8uqXw8Y3HSLVI3VepzHl3ZPJax8SyPcTe6nm2VSdo1HGORMi4jKk7K6SSwDVY9ZCLswBiNpWywrmGeS/FUjaou0e1GhebyqosiFr6ZY2pknCEnGgIJrZewsCiqrX+NWjaJYMbyqCmb3iDkaHAFU3aMebdC1vbJoTDzc9R0hjCwOFXtp7/aiUcM14FjpRKVao2KFQB9DKSuQIfHCTTUdRXtx4jrPlJ+mprxiFsVulXIVKihMRwYlTwocII8J2qADV3aZj4oU7E1uGDcKq7tRzPE8NC+w/DP5wgVVOwZ7FpIPhPHGSmjtYPWz5KsGXzXQZ2YxbosqlekQo12ox5Ig02Q06ACLNfCdPRQt6Pgw2iDP+tTn8rxo+njTKhb+f2X7OHkL+6iw3matDNKuTvD85NFtncl6E6tMmS8xO7dH8Cy1vZRNvvlxmKzQY24fQTrkc/gmFP4o2XUthuY/fJX1pS7Eyz5dWSMoW7OXFNtoxit8WtVvMTZB4UtwgB++VlIdMH1/2ZjzrkFSbBzDlkrllFo1a7bsVorQmLlUMlqbAWhiYbXFz6KjWmdYOpXs9BIKVBnWCHERjfua5b8P7pnO1EdHgvH1qeJolp3mDZba8FisHPddddRzFUYeyoKpywVrX1lL6sP4nTHCXM1vN2LMxCWfnivpf6HcaxoKGWZWNJlx+5tjB+ZW9K7dfo/35ZeTymF1ehxiobMVq+HhDLY2U70/OI0/N6OYQq5o8RTLlf5dW5KefR1HSeXX+gp2Q1dBtWZon9gD1emLBKJ3WgNw8PDzbb81+eOMTkxiVutM1OoEQ9TDPd1c/1Ijrvs8ZbZdom4i10PCRtBkW0pegezbB8eoKYVuZECOyt1tnOC++1dVEMAxc74dXSa346uueQ1Sjk2/3HvNv5cw5MP/Rq7kW9T8Vwe3baHBBZa2Vw1nWc27mJpjcYwkumhp+pz7XSBX+waQNsBb8zvZ+FVDgk5ZI9g2w6WZaGUhV9zKOayJDLzUV6TmyBfnSRWSeAU+iAzRU7V8O0a443huigRbrGmTE89hufEKbg2VRK4TgFlIMTQpV0SZoiwOMQELwYTEIQeZcsnrh0sbgeixW0LjHGpNcWztoerKpwML6XT66Lm5klgcKwYGJh1YyjbxgRxatkUJ40P1KNXJNTR+7Lxtplz69ieQ2h8MB65sLGoqQFbOZS1S4k0oIhZySh4WyI0IRYWc26R9vW2Foph2uQ806y9FSQsYkGdhUHyojGUPUhaoGrd7HxuhJyluH/XtfTMTrN74gBBPElpWxomYljVgFpngtC2iW2PUZnwQVlkwiQn95+gmBjlJwkLQsj5V5CKXcvhqcco10OenvC4pEfRmwqIOTa7d/8xx459FoiGo+Lx4fY/T7UCYTWksv9pEi9+MXYqhQGmP/3fo942vwLjT6JfeSUPPHwCg6E8Pc913nPQfSnBiQM4wRhsfwmsUpD02eKaMgvPiafuvZvi7DTX3PoGMt0bMO09PwK1YvR1EZNg54LR/oO2amvC0OBjWEyRXPLhraBeTy25GY0nWajTTis3S35ZBoSrvlGsVVvW0oTWG42AZOn2bG8foNl17XV0dHWR8NKMEY3x3zhwA/kw5Lnx1hLvdmcMuzOGirXvmVkafJxpmv9yqWyMjp444y0pQ4vnS3We+S/OSy+9lEqlQjabpdJZx5+uYHkrg01tGWpDisLMYhJqd7qfAkdxYzbJ/iR2yiWbzdLV1cWx48eiRS4shTGKRDLq2RocHFpRMO7jV+ziPl0jnBgl6DC85lU3EJRDnjy+n//jaJlTSY+jmThhbYpL/YCpQLE/m6bTyXLVi4f53e3dXJVKMDpX5n+PVqFzkJdc9S4eOXaEMjNoEwXQi9dtDRxjlsUfXzrIJw67jJ0qN4tShspBNwLvZ3uz1C2Fv+Suo2mXqVQSAwTa4Z/7X8qVwSFOeAP0+3NYvVdQs2w8nSfhV6mk4Uj/Htx0DZRFIXYJcAm28XH1Xl7Pt0jrxvvVLATpra/DjFcDas1VToJwMUAdXyiAmVj6GA2OE8NojYpSqbA9F6N6mKYHQo1vKVTCokIVq7EMirKtRt0rhdYBYVCnVl8ssLn4xgDbdRs9itEz59oxjIGEkz3t2Ilq5HcpxwZtcJSDqQck7EzzmMDUca0YtnIJjY/CwrMSOHaaQNcJ8dGNyQ22cjBGk7ZixK00loKqjto80jlMaNlMZgd42fQI+GCOFambPNNhhdS4hY1CP9NBFpeqnmLQ3Us9mCMwdfLVCXC7wY1yoE6O34LfuQtlQg5O/4qZwjGu3d6JZXkMb3snfn0OjuYoVybQhTwmDKnufwqCOtQKML1YK6nyzfbPT/xll/HUgUa9LhRWymNmbpye0hRz/+0hUlcNk9jzC5RlwUv+nxDWoGMY3Sgk6C957s/3CFZxdhqAqWNHW4Ods27IhT4GtzYS7GymVX5ZLXwwxxwrWvdqieW9FaEy+GrJ2kVrdYYcGmM7zb/SfULiy06fdJJUHI/rY/2E2gfaBxy7h+d48lB/85p2xsMtr2zrNTfdzK6dO7HbLPppWzaOWefjY2VPy/ruG/3rL/nAS2QWhwT7l/QmLbh+ZycPjcKu7iRKKXbu3NncF39RD9aJQrRS+jKWbeEnfUKrQDa++GEUs1oDKttxwWh27NjB4MAN0TIZ1hRTU99faPWKc9tKscO1OAU4rk085lIs6+Z7b3u5zvZynWMqj5VOs71S4+lsNLX+yu4U12SSjedj8dw9vXsYqqWxph5kd/4AMLB4wfjKpKY+z+Xd4Tj/3dFoY5N2bEZScUzFR+nV34T+sodzKL4DgJOxAQp9XQB4oYtqfCCrEPwwRRimUVYdbXwCFUMrh/s6fhvLhJh0Ep3pY1suT1+xRFxBrFZHN4bvbFPHtmyU5YAO0I1cJmOWpjQsttkPakykUmTqNVImIAiW1cPSsHyFFi9sPWa1quSBhrIKSQQ+ce2jTIgymtLEHnxTI3Q93DBE2x6BY5EMArQOokBKN67hL0mDa8SjrhsnCHyMUWgLsCxclcCgqbkWQWDQSuHoeDRjjiilw7Ybj9xEZ4xbKbQaRqsoeXzpxAcFxJTFNifVeIwuWvUCCrUkMdkCMseeIqGjfm472Y32Q66cO0E8LOM7LvTMk8hew5T3FzB/AlOaYmnKvVaD7O/I0uVPsKM83/izr46i/dCSN9TJU0eiBMCReJafd18Gw+DPFPk/T/4S12hKz45Sejaa8ec+8B9JXTVMcMt7+XzJY5sNzExCOgtegsqBg4RVsLPR74TjlRpdrkOHs/a6PWdjvX/ArePEF2XujgQ7W5Bu/DK026zD1K4Cqq1US1Ly8mGssGWxgtNb+tdutTwMXRba71xxXNJNMtR7DUmrAKk6PVlw2gQAyXhANl0FP0NHI7emO7FQ1XbJ41KqbaCzFok1TBddyzEtFHR0dFBbsqDoZdds5/K9u3BWGfp62aW96InutuXjLc8mfllny7aMVyd0bLyEzSXX38Sp/c8ymO3mUGPG/67YdkYZwWr0XA0PvZ2p6R8z2P0qksnoOSyXF7O2Vwvolv9SXJFvpFo/pF4+OYff2cEbepcODy4en2wMz3mOxbXdikMzS0627begMgvdl7Rcw0HxlsOP8Z1Lf4vupEehI0PVn4/apk3L29yxM9CRAM8mnJ3F+LWoZY6FCkApF9fpxhAS1xq7kStjocgH0V+6thPHjj6ZQSkcZ4w4OWqBoaACjnQmOdrVS6DARmHrEEKf/lKZF01MM5pKU1EBgWVxKpulvxpw5fQ0Sb8a9TYpD1spTmXSHOrvAWMYyuXZVShio7CMxtJ14mG4+NmhHDCLkU+gbIyyqJrdmMweJpkn7vvULM1jAwNobBSKW0erbLemMSogb1UolbZRi8V5ZngnsfIsuXiMqmtzWT5PT7nKjhoM6Qyjeop7d27D9rLcPFWkrxow7mlqgEm6XDFXQFseAdPRSvYGUqU4ppbFdRSu9gm14XkvB1ZjqEuBZUWTB4zRBDEP3+oEqwMshVbbGu+XEifScTL1Ij31YuPVWXjjLf4sKhTK7sGxLIJgEqc2T0I7YGcgLOMGPmY8iV0bBTVGuR6SK9fpyMSZyXSzvVzlVOJyfjY4hDLjvO/Qkyi1l4d6u8m7DreP3NUsaQBgXdrP08XoNcjFM/z8ktdCaQr8Cm53iv+Lm/kvJx/CWfKG92dLzP/iEJ+Z+icAZoDLClPUBnfg7tpN/tGnqA1dRvKmmwDD18ejn8kV9XbKs5hqDtW9h7U4Wq7x4HyRN/Rm6WmTD7lhlv5wH/05jDwKN7wHEp3n7pqbQIKdTdQuMlfKaikuGCxb7bzdx5l9mtygMOZQtUJW63lZzl2ShFuauYx65zCuiq/s818mHgvAa3+Ny3fNMG5d3mgQzbWDTnfGVYsKLvn+kksuYWhoaOVMqiVuueUWwjDE89Y3K81xbYaHW3MCLrvsMtxVHuOChUBnLT1JtqWJudHaQqmubnb1thZ+LA+m8JJpVOOa8fgwO7b/2/U8DODMfwFu78izUEsxlnTpq2UYKHukVqkoG7Nt3j3cy4lglGpxWSkDy4bL37DyTsvePwa4dWyaOoafDfZiLJpZn0o5XBmLU1QGsp0crczgJRxCU0MlU6haiOlwwYuRLIxiKobAj17feF8cvxQQWKCK0aK4AEYpLKVJegGpjiKBtpiydhCqCkGpCpYDjsOJWIKJbDehm0FbXvQ6GhhLVBhPZkiFhpodojHU8bGwUGFAXHvk0wP8omMxQExpRYAmpR1qpkbONRhTJ269HaUMGoUdq1APMtS7DNrONPpHQvASmHoBx3F5aEcXDyf3sUsf51A8S+Wy7SRNHNfY5NKdVFXU+ziW7eVY1meiZDOWMhgrQbWuMX6eb3dCVqVxsLCUwrEVrrGIOxUCEhil6KdEYCfAihFqqOKBBX1BnHE3isBtU8cYRc2GfDLBdr9E6Nj4VrT6q+PF6cJhNN7D8wODuEZxVbGIH/f4/bBMJQyYrlSpW3CiUCJeVNSs6B3hOEMoK8SxPNKegw7KaF1lNNBUijH2ZmLMFCeZ0HE+f8ntdMYSbKuEKAO+NgRmgM/uvY3AGDzPQWvDRPJWUpMPcrJcx+1ONd4TMJ/o5AeXvIYdV+0DpTj51K8hP4rbk+b/nX4Vf7r/3qgnj+hnWrMYEygFGkVYqhI+8xzm1MOQcCnffRwsF9U9RGz3Lh790X9n+8FDWLEOfrH7ZkYrU7z15BM46QEojAPg/fbb8Ib7CMqQfvnLUZ4Hpx6BWIZvFKP30rdHJrj5+LP0776Evm070KUyKplk+R/Cq/6chwE8+x3o2gOD10T1pgD8KkwfhKUzdo81qk4fvQ+u/pet57nAe3wk2NlEwZJeg4W3UNpNU7ehR3cv9Bm33KdREb9NcrNCadX8fkEYt5ccYS3bu1JrArOFCWPN6b6tx63DGg4+XXDQbvZWb8cwO3bsWDELarlY7My5NUv17+pAhxrHs1ac+0zneiELIlptAgvt2ljJF/4juuKX4Gma6fbEGZzux0+0Xnf5bLj+mEvR9hldZ0/6FbNjFDN9vNLXaAMuhldMTPOT7X1RQFTX/Hbw/2/vzqOkKu+Ej3+fu9S+9lJdvTcNsm82IIKySBRxAqJODFHj4GtiBieacfRkspyTQWMSnDESksnRcfeMozEzcUmMBsW4B42KICgGkEW2xm6a3qu71uf9o6qru7qr6W7oprF9Puf0gbr3qVvPvXWXXz2rAWhM9do51NBGqT3AZOvbCLMVW6CMdqmRyK3g/cYWIh80UXwshN5ixRONMmXJAioDLuoPNLN3ay3VIsFRmWCnZwZGfAeRhJ9ow2FMPYFwG+haDjFqUhOHQUIXtAGGyw1xiYzJ5PlvsSLx0QwkQiES0RDIBAkBwrTT3mzQ1rw/2RvJHUBY7Xhra3BKK1JLEBURsPjRYg3YpQMzodMg2omGrERlDGHPRUZqkte1xZd8qFh9xGQLdSKEiSTk8JJIxGnVo7RrqXZ3MjlthxAiOU9eKMZOmwTdC6YNYYIM1YBm0ODIQTbtR8jkveIFn4lu9WNzTUqfFwmzGBK29G1HpIYY0GSAvIZqYrqgoLmZv5aWIHWNrakg1mVYsQgdS76dp3KT1aAWmeze/zebG4TGR0ebyInGMDTJ4aYYbunDsEXIiTWyV2vFiIHAYHJIJ+FzIr1zEMdayLNJ4kLwRl4+fprwJeJg8xE1dXYZEruUxFLXT0TTweKgPVUFv6nNzuuTinDpgiuix4im+qitd+QTKK9MP7yvPPdcHn/r7eS+An/MCTIx3Exk618YHaqn1eagNpIAJPkWnTiCtrjEqgkSXa/7RBR5dD/tR/fzRwqY6wsxveEQH8g2sLnY48pjbCrQAYj85al014X25+7NuFYi569Ed7nYWVPL+GOf0HRoL7Khnba9n2AdPRpGj0FGu1SJSolMdSFPxGPEIhGsDieJQ+8TObgdW+1O2PlC/y7U9kZo/izZQ8uwQOtR+PDJ5Lr8cZA/ITmquCM3GTxFQ2A6egZDiQSEm06LUiIV7AwbgW5YiEXbMTQjXdqhCUG5uxRn3Eo8EutRbRXVJSEjTp0MU9JluZSgpSIhmaV9ixSye9zULzOr64i57RzO6V5F1f8H+0n/FsiygRxXoM9A50S2b1pTowyfgIH2BOvK4fV16RfUka0h/BXVNa+A396OpdiFzWlScNYoLN0aYPsdgzPfz/j6ambZfbxRGaQhtazQbmIHWkwNqQuky5qx55phYdLYMwiHDyFEsrVGZb6XhT4Xb75VTaTdoC2aCuQFmJpIT3pZJHWK0Fno8DNmxlRikRDRv/wnH+NmQ5GPMCabGmuSb+z6tesi+ZdltzWHAyEdkIghoxGE1Y60C6SvAjSBZibf5HC2YETjhMMOdN2CrlmxCRNHwpK8FIUBIoZIjRkk9SylglqyJ2I04kJKjbiZi16QjzAsyS7z3a8BCeJoqou+ECAlwl2cLAlriiK8Fclk8RihRATD5iRhbUdakyU+WHKxtQgItyYfcrHkD7KQRbK9wEs0FmW7z4EuEljQiKXaXCUiOu3A/zqsOOMJoglJPCGxmzqaEMQTkj/kedPZasxJPqQXHm7ATLhwxsI0mvUUxDSOuiXtwoMUAqc7WbL9mzFjiWkGRn4YKTSk0InZ7AigXUAklqAtGk9N4BZHEwmcVp2/2KAxFKUReMyXly4FL6gYjcWRbI92RWEuJTYLzwcKaaipBmCbxck2i5N5M8/HDNXzZ82BbprIUCOfNYT4zPRBarLiXRY3cQltqXG0nLpIP/M3BkbhDTXRETMDfOr0s9uVx9zavdgSndWaO9z5fOgr4pIDW9GRxPbvJgY0tccJbUsGYjG3Cc1Rwpv207jtNQ5bdVqbk8dyT+ov+b0lQ6ixLoP9bXFiTitj3RYsLe1Y8j1EG0LI1HAfhs+J0DVsZTmQkAiLgRmNI449QCIaJ3KkkZYPDyZPR5uJe+o+LIHOAWf7pXQWFE4H5/BNmqqCnWGVPPsDjswRiDsCH8gen7SZcWKxniU7esxI/78rQ9hS3aczlyeEREttJtFLM0lvJIa7tZ3D3QfR7UhcNB0Ob8nyzsHz+S047R+nLyezMfUg947o2Wan23kgYbRNp9ZpUlpaSs6ono2MvQ6Tr84qxd7bmER9caUaMWvJmeDzPDZadSuReBt2i0Gey4LbZlLTHElWhXWj63qPfAsBYoCNNA1NxyBBFY1UlfnB7uP3e7bz0eEmPgoG8DlMmttjHX2vCEqdBhKMlTo1IkE9kqJ8R7JHl4RPj3X2ohK9lPwZRjQ96KeGIKSFGd0COdFmdgT8+LFR7kzgOVTDbpefo1YDTRM0tXVtyCyIRZ1gsaaDKUSWYD/LxeK0GEQsWuYoQLoBukEsLjHidjQ9SgKI6yY2UwPTkgyU4lbiApoLbERbahChZAvAmCaIxpvSQXNYk+gy2TezOaZjkyYxkSAe7jqfWM8R4V8t8nV5lW3+vsx2L1G9s71PY3vvkyMnpORIJES71pmmuqGdPLeVM6ZNSy/rCHQAVuU5uKMmcztvWL1g7bwehMOP4Q4jG2vQzGRJyu+sU0mEOz+npVuD9IeLpqCbBkLXeLx4IgKIt0X41BGhsu4wfz5jJoFwC21OD1ZN8FzxJC4+9GGv+5beR2B7c5Zj0GUU/p0dmWlqpzYcodhmEKnNnP8v1pA8h6N1zRnL6yJxGmOSCruerp5PtEdpfGcP+Uun95m/DAfeTf6dff2wlfKoYOc0pOsmHQODRTImPTie5DQB2W52ujARqQEBBV1+wKZKe+JIYgI0JPEuVVZdHyMZzxktGTZpTicUTD7hYGcgQUz3tJqevVTn8zSSqdNqpwVw52SO9mrRU9/VINWPm2bfE1gWGCZj5sw5blVdcbf5w0zTC7TRTkXfmbD7wF2YDmRmVuTgPSg50vopkCBHJrCVl+NpjSA+S96sPXaTQw0dVb1ZGn1nbcCfXeeh7JnCYzM5qyIHpybY2W3dGJks6Vsxq5TfvpscCuHrlUXku61IKVn30q6M9N/+0hja4glsusbWu/+APZSPAOrOOYc9B1uIhcNMaG6hpj5CvcVCyZEYl/7DmbQ11vHy4TijIi00+XRisQQWXaPo2DFKWlrQgLgQ1JScQZ7bJISkFUkhGo1ImoRkVKWPAsNgV8NnzDVsBP02Qo3JYzmhqoiNGw/SkGqMLmOSP8ZCtEfjtLePIlhkUtvShoFJtqAEwHDnQbiFeDwV4Dm9yWqKUPLhGdcSyfuJiBEuKgegFZCxGGgCXWokNIFEYomBOxSnyaHhr2+DaDsy3n1g0YGpNVrQc0qJGwJhJM95GY/BZ5+m0zS2d37G8oA/HegAuNxulrXV8aw9l8Ix46j+pLMLe1fCakUEkj0DBaDndisLjoSgpTZZKmfzgWlLtptprUU3DTBsaO44BwuDHAyPxQTqSVb9tQObrSbv6XNIDWQFwNvlkzjz4A72hjrzXx8Z+ECGjdEEFk1g05L3l3BCcjQSJy7Bqgn8Zuc0Pgfakp//USzBFM8gzeS+awNMvXxwtjVAKtg5LXWOQ9NC8/GTdrxDdv1/9lt+R2O77vWqcSFBGMTJ/kspZsv8pa3pBpbyMnKuPAvCR/uVv2w0W/9KCTpy67S6gSYmTB3D1KrSE/7cgdCEnh5rpC8DqcbSfT4KImH0YAGmLXMSSb+9nWbA5bd1vd9lZbUmf/nqRu+jqZaXl9Pe3k5BQUEqb2SNCm3d8tGXoqIrqA7vJlzX9/dYWlTEp7pJIPUQsmiCUXk+vA7YcXQvU2JhDLeDGUW5vNh8mKDXxoKx+YBkUpEXwh/12GbW3oqpw95rO6WM76Uzja4JphJjKjEeznJbdNmMjLTJTWV+x2ML3Fg0DUuqamln4ZlM27uPxNhJTBldju3gdmht7dnYv8v3IaTsEY91hPW6lBRFoggEVgT+1PIcBGMcFlZWJs+FVo+H9tYoLfXhdLDj9FrI1Q38HdOGaPAdiwcs8DctRrCygAtyPTz89HaK62IYmiAWl2hHoxTkOimbfQbvHm5k20e7CMfqiLqsNOblkaNDc2sNTV43sYSkLRInFmrHJTWOidRIzqkOBB2PZoEgasIxb2qgQo8NV5sFAdS7DZztcVrsOnFdpL8idyiGlgBLTKanNmi164TsOmZUEicO5JAwzW6HL/NVwG1lnNPOsnxvj+/PkxdgatUsZrnc3N+aoHTilPS6tuZmjh7YR79YHJBTnrlMN8FS1jOt1QORFrC6IR4FIdCEhuYLJ9vE6BYIt1CT76clXIf1yJGe2+in2nCC2l6643eoznLDiUvY0hhhqsdEEwLvWZVZ3tlP3pK+0wwRFeycjtL34M6LMdruA8/hXsfkONHKHpnxcT1/JUc1gcVqpLcvUiNq6B5PcobgfhQ89ZYzc0IuHOpHJpN1cNhMB6V5ZzBxyphU25qhN6pgIvtqtpPvKe4zbdf2E321J/Jd/hVcmzbRHO55AHPtbRTPLcTq1Dn61u4s7+6k6zbKy1chRO/HwzRNJk+e3LlADE4JmK5bEUYQ6DvgdbpczLA7UgEKRGtqgM66UXdCcn7AB8DKuRXpB9GSyckHePWRLCU7mmDOqBz2xuBvByEu+vHrUzOSN9xENPmrm2QVWTzeeZN3Wg2impYMcFK/NXQhmFbqpS2SwO/IXlLWvbDxikuX0Njaht/t4Fh15qCBGskeYkmdP0AE/Wtbd3ZlLo1tEcYWuGlsi3JGQef4TE6fFafPSvOxztFoNF2janEZh3Y1UL2rIWNb4xMGZ6Xa0yydXUb1Gwfw2k12VCdLbDRN4HZbuGBiAda/HWV/bQ2mRSdgiYOU7Gs9Ro3fS4GMMla0gRPmnj8xa75j8QSGrvH05oPsO5pspeaMxSivS+b1ba/JVlfnd+1A4EHjiBOskQSWWDxZYpISkBp2XfCplr2F21y7DXEoWbIzZ3QueiTM7NR5lk1B5RgAvpt63RZPsKctzIZIOH2Wdw2CuouGw3y2ZxdWuxN3Xh5CCAyLFc0w6JjqBUAmJIl4DE3XiUUihJoaaTrapQ5N73KOmclmCLGq83HGu03q20X4k93E6uogEcVSXoFRWJw8raLtyR5ekGw7094ItTuRmhVKqhD1e5AdjabjEhlPkDBy0Msmgq4T/uQT4vu30yo1Ku98tDNvHXW5rTXJQM2wJdsLhZtJ3mTisPmxLvthh/LsUxGdCirYOQ1VN3yKN1GI3uUBVhfyE60di88ahCwDDUrZ5U7bxwB8Aoku48QEuGQb7b08JDpqxZJdLTt6ZXR000gl8hSDKx8c/a1u65Rb5sXutmC1H/807FoD4dWtxy81GeRqLF3TGR3s/ebWldVqZezYsei63mewo9lsGAUFcOBAj3VCgCfXnvEAPm4es8wefVySrOMEnYgCdz9Lg4RIBzp9J+1/3hymwJJq2FvjGtf7NjvOIiE65/9Jfc6ZZ57Jnj17aGpqIhaLMUNEqS/zM9/nYuOmZINVXRMsGl+QbdO95lvTBP7UoIzdz8uOiVx1TWSW7ACmTSfWkkAYvbfeclh05owu7GVtdr1V/XYVKHbjX1RBXSwGzzaTyLVSOiEHPfVeh8cKtWDvqNYQAh2YF2nqfaNdGHpHj9DOY9Vq1zmUb6XdolHpsuFpyZxaZUa5n7c/PUY4GmX6sRhmqvBr4YUVWCu8vN/Uyp/rOj8/Gk/w0aEm8t1WJjhs/I2uE+cOjF3XmOSyU1mcy4Mft7HTTFblFlhMPoskS8K/lOvBpev8vqYe02qlZMLk420yuf+aQE8N82HabHhtNryBLueXhFg0QqQtRN2h5D2iON7Pe6xmYhZ1+XFm2qBsdvL/ugmuAFjdycEdNQ1Me+f3oQuErqH5vGAm78uW8jLC4TBFX70qMwjrqCVwd2tr1XVg0VHzkmP3VJyTnH5jGKlgZ4hVTM1j39aBVfXE4lEOh6spNUqwY6eNNtq1BJF2Px7TCvScl8VuMdKNyLqW/uhZLvLSSA0T2/ZypKWEIk81T3tmZs2HhpZ+f2lTE+FYmPzWEAhL5/QAmgYzvwEtr/a6P709vDRdkFPYn3nAkr1rrHYTv8163OBoyEYV7afi4r5LgE7E8cYSGqhwKIaek4Nee5R4c/+qSXtTlutg6dRCcpwDq9O3jh5N9Gh9v2PTXnumnXEB7HiJJmshCc3sPVDqurhbGrfbzbRp0zh27BgffPABcwK5TEpVCUUrwggBtn40zM42mGSH7kNF+Fw6daZJTsCD0AQy1atJkxLTqqPpGrFwFOnJRbT1bM9yvM86WWbAQYGU5DotWAwN3ei8h5wxM0BtuwtbL6VbJ+Ksylze2ZsciG/ZuAC/23Qwve6CiQWMC7rZXdtCoiWOJcsJM9ll56OWNkwhONAewdQ1bp9VSX00xhSbSbzAjcd2cteP3eUmv3wUtYnkeXBZgZ97DtQgEFR5kvewm8qDPHyolsZY5o+UgMWkJhUYzfG5eKshOQdVvsXkwjwPz9U2cpbXyRSXPX3+xhKSF+oa2d5ioWDfDiZGWzGA0TNms3vTX3vJ5XGuJt3Ek1+Q7J6OpHzydNpampHxOIYxm0/+cA+6O4DT48GvN2KrupzGYw0YVivu3Hw8VwVOrA1hxbnJIMcYpDY/J0EFO0Msv8x9nGCn95OzJdYKRv+7H2tCo7MJQ+d7TJuOlvqhJIDFLZvR4yEkEi3kQvp6bssUdhIyhi46b2hTW2PkNdQihNG5sQ6nYqApAXmlLiZVBI970dmcg3cTHmp93Ty6rq+qqhq0z9VNDaFp2CaMp/3jj4HGk9pe1yqU3vToSZVqCG3R+3sL6uVY5Y6G8VaaG5IlMCcTBOTk5DB37tyMASjPPWOQusp2u9R1XZBT6MKRkyz58abaU3X8uNANgUczMW12mLaI4O7XOdLYDkLgthmMC/Z9zAtHezl6oJm80i5p+xldCiEYW+RBxiV6TmfpnW5ovV5jQtOS47z0Q9BrY+/RZNXezAp/OtiBZGlXPBX8TS5OlhJcM7eCh575OHMjqX2xaBpXF+UhpWRzU4hci0G53QpYicdi5LkG50GbV1aBqymZZ5ehs6o0kG7MC8khD75VGmBrc4gc0+A31cmhxfMsBqU2C7tC7ZzpcfBxSzsNsRhnOKwUWi18syS/x2cZmmBJnpcqjwOLdSY7/vIaAIFRo9PBTm5JOd78AHs2vwuA5vZA3bGM7Zxx1lw+2/MJbS3NjD9nAUaXzgqe/M5ewHnfuatHHvxZmhidkNMg0AEV7Ay53h5o6aXW41dVZJsZvZdP6hIYZX6tHptBnS4RcYldRtODWB1yNuNL9b5KSB2pa+iaiYZASwU6nZ8uk9VqWSbxHAhbaotmH7uVUUDT5cP6ChC8ATtlk3NxegdYtTMMupdCeS+9lJaXX8a1cAGQua8DbTx82unRbTz52mVxUuotxFt+EkGFbhJw2whFYpSlgocTLeAb6CCU/dVXfuwuN4VnjCOkm2xLLTM0wYQiD9edO57tb9Wx/vX3Ib+UlXMr+lUtY3WYzFhSkVFl2Z8JbNNpZxcSqw1hKekMlrJdf06fH28giEwkMtudHMfMcj+mLijPdWLtNodUtiu8P6UKQgiqvM4eywZLrpl5X3X3MvfV1FTV5VWFuXzY0sa5fjcOXeO8HDdCCK4syuFAe4QzHMe/pnUhKLRaiHTprdl1f5x+P8ExY9PBjhHIR2gamtuVTuPw+pi08PzUmEynpp3j6UoFO6eAy28jFo3T3tL7uBDZSClp61ZlpWvdbwypqisp0DWBLnSEacmYe1AXIms33ZiWQKSi7uZQkJitDUfbNGBvj7zEZSLVNkjil1lGysymfC58ujH1b/IX3zcry9myp43Zsv+n3gSnjbeaWglY+i61EUIQzDJOzOeBpaSYnH+4Ov1aCMG8efOQUqL3MnXDiegaZMksvX+GRPfzpcu0GiXeILY8f5Y39V9lfvIhl546pXtnrFOxj8chOxpzpohuvSKllBimhVj3sbBSryecPRdRPgld1wfU/qR72yx/0MHoqgC73+87KNGdJrqz72spp6iESQvOI9TYwIevvkTxuOyNk7sydI0Z5d0H7+pL5/GbUtK/a7xHsHMSJ8JUt51QPEGZvX8lFUU2C0VdurZ35MWp64x39n+uPovNzoR55/U5d6AQAiM/+aNh+oVLCYdacfr8qXVf7EAHVLBzSkw4pxAkvPtcZhARj0XgOPetpnhmewqL5sSm22ghWeeroWMzbITj7YDAYdjRNYN4zEXYSF5MFpuBnhqPoSMw0oVGkx7BqrkRemfr/rAwkfHMX0Ydt5eu3a9zcPbvpjFqfnIuFrsfPn0VgKIcFxVNFtCzT6aZzdleJ0V2K0XWz08V1WAZzLY6HTJ+3Z+qJk7diza6NeC2FLs4rgE+pPpfIjp4jtterPsqTzFoPceV6W0LQggmZAzAd2KEEOQWu/oV7AyUw+tj1sV/P6ilKV1NKvLQWFPLhEI3TovRv3O3lxLFE6EJwVx/H+fpEPEHi/pOlGJabTg8Xhyez+ePvqGigp1TQHTMKNdNIhE7brBzKHI447VFywxEDM2GlorYpRTpYkqn4SKhGWi6hivHStmBVo7Fo4yOthPMyaepLUpCNuENFwO1jAnvZxMlTA004Wzvdkqk8h1KtNFRVSYyqswyOZ1d8igEODJ/vWmahmN6gL50nXBT1zQqHYNfveDwWgk1hvvVSHogxf+nu66N1i0V5WhHanCek72R+qA5TrBjrfQiTrC3THLTPZ96voCD/XSZjv0UFO2U5fY+1pGUEowu51DOKIjvSq/r6L3nR1JWVsb+/fsBCGqnPmg7nr56GQ5GoNPbJqrK/DQ3xDBSeRD9GKdrqAKv00LqvJ9+4VLamhqxudwc+GgrZZOn9fHGL6YRE+zcfffd3HnnnVRXVzNp0iTWrVvHvHnzhjtbfeiri3gnmV6WXGo1ksXZusiWuvOGJITA7TKYG/4Ql81LwYSp+BK17P+0GNGcLNUpi1QTrj1M+YQY0mpg6BqxeCLjcxPpLqPpDWfkdebMmbS2tpKTk71ourS0lHA4jNudvWFl91nJdVNj0vzi5BxHg9RNurtxs4M0fBYip6gz2Bk7diw7d+5k1KhRGWlLJw60yL1vdnv/i7KHiu50Unr91ZhDXGqWbcqK1NRNGDkDa4+UHLm568Z7prE5TaZfUMaWDcmgYageef/vnAoO1rdhM3VG5/cRNFvdkFOZHI+kCyEEhmEwblyy6/z74WRu5xAh0J+xg04hu91OaWkphmGwd2/P6u4TNaXYS30o0mOU7kwiHehYyz2Ywf705MxUPmX6iWXwNNa1FGf8OQuGOTenrxER7Pz2t7/lpptu4u677+acc87h3nvv5aKLLmL79u2UlQ1Wk/JTTwiI63FiCYhoGlbA5w5Q21aL1dSwGTYQERIJEy011orVsGFqjXTMKWO1WmkRvvT2SiquIJEIc/jQuwj2IvTkzdSSSCAEBEf7+XinhtYR7HT7xZ1IzbDc/ReT2+3uNZABGDNmTNblkydPpqGhgWCw57w4Q93I2LTq5Jdl5rm4uJj8/Px08DXlvBLaW6J4cgc/MCksLCQcDuP3n1x7lZORX+4Z8kCnN675JSRCMYx+lJrZrIWEWvcAyZGbu+qt9sjSpbvxUAXMPocFXz8mSU1fL56e1REuV7JqpKgoue4fY3Fe3rcDb+paO910XMuDGeycP7FzjBmRpX0hgJlnow3QPRZsY/t/zUy/cCnxaBSL3Y7VMfAASRkZRkSws3btWr7xjW/wzW9+E4B169bxwgsvcM8997BmzZoe6cPhMOEuI9c2NfVvQKzB1b+bWMyM8amzkbDDSaB5NG5754OhrWkmhu0T6o65sTlduGxeLIYNm1XHYglQGMij8uwpvPpKO421Z1NUWoUQGrpuZ+7cueiB0Xy6OzkbUDyeHL9n9NQgb7+i064DcYnhTg31bmrIRBzTpuOyW5Fy4POyZJOfn09+fs+ul8OpaymT3WXBPkhdV7vTNI3KypMYev0k+AocNHwWIjiq+2z2Q0PvEgj7v34VAJpFR7P0r+Gk13smmmbBbi/tMYiir8BBY00I8zhjqVj6OTXJUMkpdlJ7oBlfwM7Bv9UDUDV1Fv4iR49STY+h40uVenm9p3+7i8FsPA/JXmiRLMuFqeNZVDrgKknVdkWBERDsRCIRNm3axPe///2M5YsXL2bjxo1Z37NmzRpuu+22U5G94/OGocso8rqhEY9lBhEWzU5Cb8CaF0C06CA0DIudWKSNRNxNbv75VDfvR4gE1tRImHnlHvIrZ+HIs6FpGqbFxFdQTuX4zhFmDcPgnPHFvLv/H6g/tp1W92HG+schhMBrKaY9th8MgdkeB4dO3KLTpoUxDQdCE8Q9p1dbAmVgzphVQDyWwDjRWcwHSBgGuf/4rWSpYD8mJu3xfqHj8UzNui5Q5sZqN7K2q6o8M0DDZyEKTlFQ1xtd15h4TrLkJtQUpaW+nUCpD93M3gZm1qxZ1NTUUFIyNHMJefLtNNX2HJx0IKZPn87u3bsZO3bsIOUqafn0Yp7fVs38sT2HIziZtl3KF9vnPtg5evQo8Xg8Pclhh4KCAo70MmnaD37wA26++eb066amJkpLT83Ekh0q5nj54K8RaO288XcNdhKGhh6NY+gucs1ROG0zkHoIm27FkmtFi8CcM+cweloh+tMfkRw3OVmsLITAU9F5c587dy6xWCzrGCJTSn1skePQErksLJ0LwKTCAJYaBw3hGjSvhXB7AwhIWBIUlzgJxUKUTOy7kbFy+hJCnLJAp4NmGZoSMqEJfAXZGwfnlbjIKxmeHjS9GV2VLMk8XhWV0+ns0W5sMI2pClB/JEQsEienr55wvfD7/cycOfgN24NeG9eeO3T7PmKo35sD8rkPdjp0v3FI2Xt9t9VqHbLBw/rL5bVl5K8iMJ6a0KdEUiPkxOwGUhc02MHuK0bXDBIVTkpH5VMRXITTacdvS9ZbO1LdzDsq5oLB5Rmfpet6r0XN54zJIyFhQmEFhpY8HYqmBohtkXzWVMjEy8bz0Yu7iCWiRKlHNzWiZhRPQAU7inIiTod2OIalZ3s15fPFGKIfDyPV5z7YycvLQ9f1HqU4NTU1PUp7TidBZ5CJEydSXV9PgbMUi2HD784j1HIAQzfJ8xRh6haqnRoiNfnaWePzKR+T2+s2LdErKJtsx+Hof6Nsm6lzwcTM42Qd5aXCYTLGb0WzGcy8YCyNtW201LVT+2mykejpcMNWFEX5ohkzaw4Nn1UTqBw93Fn5XPncV4BaLBZmzJjBhg0bMpZv2LCBuXPnDlOu+iaE4KJxFzF34nl4HckA5syzJ1KUM4ry/PF47H6KygLpQMdiaJwzJvuQ+iUTkt2iXT4XhaNOvveZ0ASWQidaqsGnw2OhcLSX0TPPwmKzUzR2wkl/hqIoijJwgYpKxs4+5ws//cNAfe5LdgBuvvlmrr76ambOnMmcOXO477772L9/P6tWrRrurPWpYkoeO985QuFoH76Ak/mXTEXTBE1H23Hn2uCV5CSNxytIKRztxZ1jw+EZ2mJNTdOZueyyIf0MRVEURRlsIyLYWbFiBXV1dfz4xz+murqayZMn8/zzz1NeXj7cWeuTzWky9bzOxtEdjUY7GlwW++wcamhjYmHvvUmEELgHODCboiiKonxRCHncCV2+GJqamvB6vTQ2NuLxDF0X1Xee3ZP+/1nL+je+Sns0zsH6EBW5TgzV7VJRFEVR0vr7/B4RJTsjmc3UGRNQvSYURVEU5USpooJTaOzsIFaHyfi5hcOdFUVRFEX5wlAlO6eQL+DA96XeZ0ZWFEVRFGXwqZIdRVEURVFGNBXsKIqiKIoyoqlgR1EURVGUEU0FO4qiKIqijGgq2FEURVEUZURTwY6iKIqiKCOaCnYURVEURRnRVLCjKIqiKMqIpoIdRVEURVFGNBXsKIqiKIoyoqlgR1EURVGUEU0FO4qiKIqijGgq2FEURVEUZURTwY6iKIqiKCOaMdwZOB1IKQFoamoa5pwoiqIoitJfHc/tjud4b1SwAzQ3NwNQWlo6zDlRFEVRFGWgmpub8Xq9va4Xsq9w6AsgkUhw+PBh3G43Qojhzg5NTU2UlpZy4MABPB7PcGfnC0cd/+GnvoPhpY7/8FLHv/+klDQ3N1NUVISm9d4yR5XsAJqmUVJSMtzZ6MHj8agTfRip4z/81HcwvNTxH17q+PfP8Up0OqgGyoqiKIqijGgq2FEURVEUZURTwc5pyGq1snr1aqxW63Bn5QtJHf/hp76D4aWO//BSx3/wqQbKiqIoiqKMaKpkR1EURVGUEU0FO4qiKIqijGgq2FEURVEUZURTwY6iKIqiKCOaCnaGyOuvv86yZcsoKipCCMEzzzyTsV5Kya233kpRURF2u52FCxfy0UcfZaQJh8PceOON5OXl4XQ6ufjiizl48GBGmvr6eq6++mq8Xi9er5err76ahoaGId67019fx/+aa65BCJHxd/bZZ2ekUcf/xK1Zs4ZZs2bhdrsJBAJccskl7NixIyONugaGTn+Ov7oGhtY999zD1KlT0wMDzpkzhz/96U/p9er8P7VUsDNEWltbmTZtGr/+9a+zrv+P//gP1q5dy69//WveffddgsEgF1xwQXqeLoCbbrqJp59+mieeeII333yTlpYWli5dSjweT6e58sor2bJlC+vXr2f9+vVs2bKFq6++esj373TX1/EHWLJkCdXV1em/559/PmO9Ov4n7rXXXuPb3/42b7/9Nhs2bCAWi7F48WJaW1vTadQ1MHT6c/xBXQNDqaSkhDvuuIP33nuP9957j0WLFrF8+fJ0QKPO/1NMKkMOkE8//XT6dSKRkMFgUN5xxx3pZe3t7dLr9cr/+q//klJK2dDQIE3TlE888UQ6zaFDh6SmaXL9+vVSSim3b98uAfn222+n07z11lsSkH/729+GeK8+P7offymlXLlypVy+fHmv71HHf3DV1NRIQL722mtSSnUNnGrdj7+U6hoYDn6/Xz7wwAPq/B8GqmRnGOzdu5cjR46wePHi9DKr1cqCBQvYuHEjAJs2bSIajWakKSoqYvLkyek0b731Fl6vl9mzZ6fTnH322Xi93nQapXevvvoqgUCAsWPHct1111FTU5Nep47/4GpsbAQgJycHUNfAqdb9+HdQ18CpEY/HeeKJJ2htbWXOnDnq/B8GKtgZBkeOHAGgoKAgY3lBQUF63ZEjR7BYLPj9/uOmCQQCPbYfCATSaZTsLrroIh577DFefvll7rrrLt59910WLVpEOBwG1PEfTFJKbr75Zs4991wmT54MqGvgVMp2/EFdA6fCtm3bcLlcWK1WVq1axdNPP83EiRPV+T8M1Kznw0gIkfFaStljWXfd02RL35/tfNGtWLEi/f/Jkyczc+ZMysvLee6557jssst6fZ86/gN3ww03sHXrVt58880e69Q1MPR6O/7qGhh648aNY8uWLTQ0NPDkk0+ycuVKXnvttfR6df6fOqpkZxgEg0GAHpF3TU1NOtIPBoNEIhHq6+uPm+azzz7rsf3a2toevxiU4yssLKS8vJxdu3YB6vgPlhtvvJE//OEPvPLKK5SUlKSXq2vg1Ojt+GejroHBZ7FYGDNmDDNnzmTNmjVMmzaNX/7yl+r8HwYq2BkGo0aNIhgMsmHDhvSySCTCa6+9xty5cwGYMWMGpmlmpKmurubDDz9Mp5kzZw6NjY2888476TR//etfaWxsTKdR+qeuro4DBw5QWFgIqON/sqSU3HDDDTz11FO8/PLLjBo1KmO9ugaGVl/HPxt1DQw9KSXhcFid/8PhVLeI/qJobm6Wmzdvlps3b5aAXLt2rdy8ebP89NNPpZRS3nHHHdLr9cqnnnpKbtu2TV5xxRWysLBQNjU1pbexatUqWVJSIl966SX5/vvvy0WLFslp06bJWCyWTrNkyRI5depU+dZbb8m33npLTpkyRS5duvSU7+/p5njHv7m5Wd5yyy1y48aNcu/evfKVV16Rc+bMkcXFxer4D5Lrr79eer1e+eqrr8rq6ur0XygUSqdR18DQ6ev4q2tg6P3gBz+Qr7/+uty7d6/cunWr/OEPfyg1TZMvvviilFKd/6eaCnaGyCuvvCKBHn8rV66UUia73q5evVoGg0FptVrl/Pnz5bZt2zK20dbWJm+44QaZk5Mj7Xa7XLp0qdy/f39Gmrq6OnnVVVdJt9st3W63vOqqq2R9ff0p2svT1/GOfygUkosXL5b5+fnSNE1ZVlYmV65c2ePYquN/4rIde0A+/PDD6TTqGhg6fR1/dQ0MvWuvvVaWl5dLi8Ui8/Pz5Ze+9KV0oCOlOv9PNSGllKeuHElRFEVRFOXUUm12FEVRFEUZ0VSwoyiKoijKiKaCHUVRFEVRRjQV7CiKoiiKMqKpYEdRFEVRlBFNBTuKoiiKooxoKthRFEVRFGVEU8GOoiiKoigjmgp2FOUL6r777qO0tBRN01i3bt1wZ+dzSwjBM888M9zZAODWW29l+vTpA3rPI488ghACIQQ33XTTgN776quvpt97ySWXDOi9inIqqWBHUYbRNddck35YGIZBWVkZ119/fY+Zjk9GtodxU1MTN9xwA9/73vc4dOgQ3/rWtwbt85RTYzCDLI/HQ3V1NbfffnuPdY8//ji6rrNq1aoe6+bOnUt1dTVf/epXByUfijJUVLCjKMNsyZIlVFdXs2/fPh544AGeffZZ/umf/mlIP3P//v1Eo1G+/OUvU1hYiMPh6JEmGo0OaR6U04cQgmAwiNvt7rHuoYce4l//9V954oknCIVCGessFgvBYBC73X6qsqooJ0QFO4oyzKxWK8FgkJKSEhYvXsyKFSt48cUXM9I8/PDDTJgwAZvNxvjx47n77rvT6yKRCDfccAOFhYXYbDYqKipYs2YNABUVFQBceumlCCGoqKjgkUceYcqUKQBUVlYihGDfvn3pKpCHHnqIyspKrFYrUkrWr1/Pueeei8/nIzc3l6VLl7J79+705+/btw8hBP/7v//LvHnzsNvtzJo1i507d/Luu+8yc+ZMXC4XS5Ysoba2tt/71d2zzz6Lz+cjkUgAsGXLFoQQfPe7302n+cd//EeuuOIKAOrq6rjiiisoKSnB4XAwZcoUfvOb36TT3nvvvRQXF6e31+Hiiy9m5cqVGZ87Y8YMbDYblZWV3HbbbcRisV7zeejQIVasWIHf7yc3N5fly5ezb9++9PprrrmGSy65hJ///OcUFhaSm5vLt7/97Yzgsrq6mi9/+cvY7XZGjRrF448/TkVFRbq6Mdv32tWjjz5KRUUFXq+Xr33tazQ3N/ea3+PZt28fGzdu5Pvf/z7jx4/nd7/73QltR1GG3TBPRKooX2grV66Uy5cvT7/evXu3nDhxoiwoKEgvu++++2RhYaF88skn5Z49e+STTz4pc3Jy5COPPCKllPLOO++UpaWl8vXXX5f79u2Tb7zxhnz88cellFLW1NSkZ7uurq6WNTU1MhQKyZdeekkC8p133pHV1dUyFovJ1atXS6fTKS+88EL5/vvvyw8++EAmEgn5u9/9Tj755JNy586dcvPmzXLZsmVyypQpMh6PSyml3Lt3rwTk+PHj5fr16+X27dvl2WefLauqquTChQvlm2++Kd9//305ZswYuWrVqn7vV3cNDQ1S0zT53nvvSSmlXLdunczLy5OzZs1Kpxk7dqy85557pJRSHjx4UN55551y8+bNcvfu3fJXv/qV1HVdvv3221LK5GzRFotFvvTSS+n3Hzt2TFosFvnCCy9IKaVcv3699Hg88pFHHpG7d++WL774oqyoqJC33npr+j2AfPrpp6WUUra2tsozzjhDXnvttXLr1q1y+/bt8sorr5Tjxo2T4XA4/Z17PB65atUq+fHHH8tnn31WOhwOed9996W3ef7558vp06fLt99+W27atEkuWLBA2u12+Ytf/KLX71VKKVevXi1dLpe87LLL5LZt2+Trr78ug8Gg/OEPf9jrOfjwww9Lr9ebdd2PfvQj+ZWvfEVKKeV//ud/yvnz52dN1/08VpTTjQp2FGUYrVy5Uuq6Lp1Op7TZbBKQgFy7dm06TWlpaTp46XD77bfLOXPmSCmlvPHGG+WiRYtkIpHI+hldH8YdNm/eLAG5d+/e9LLVq1dL0zTTD87edDxot23bJqXsDHYeeOCBdJrf/OY3EpB//vOf08vWrFkjx40b1+/9yqaqqkr+/Oc/l1JKeckll8if/vSn0mKxyKamJlldXS0B+fHHH/f6/r/7u7+Tt9xyS/r1xRdfLK+99tr063vvvVcGg0EZi8WklFLOmzdP/uxnP8vYxqOPPioLCwvTr7se3wcffFCOGzcu47sIh8PSbrenA6iVK1fK8vLy9GdIKeXll18uV6xYIaWU8uOPP5aAfPfdd9Prd+3aJYF0sNP9czusXr1aOhwO2dTUlF723e9+V86ePbvXY9JbsBOPx2Vpaal85plnpJRS1tbWStM05a5du3qkVcGOcrpT1ViKMszOO+88tmzZwl//+lduvPFGLrzwQm688UYAamtrOXDgAN/4xjdwuVzpv5/85CfpqqRrrrmGLVu2MG7cOL7zne/0qAIbiPLycvLz8zOW7d69myuvvJLKyko8Hg+jRo0Cku1+upo6dWr6/wUFBQDp6rKOZTU1Nf3er2wWLlzIq6++ipSSN954g+XLlzN58mTefPNNXnnlFQoKChg/fjwA8Xicn/70p0ydOpXc3FxcLhcvvvhiRr6vuuoqnnzyScLhMACPPfYYX/va19B1HYBNmzbx4x//OCOP1113HdXV1T3ar3Sk/+STT3C73en0OTk5tLe3Z+zXpEmT0p8BUFhYmD42O3bswDAMqqqq0uvHjBmD3+/v9bh0VVFRkdH2puu2B+LFF1+ktbWViy66CIC8vDwWL17MQw89NOBtKcpwM4Y7A4ryRed0OhkzZgwAv/rVrzjvvPO47bbbuP3229PtSe6//35mz56d8b6Oh2VVVRV79+7lT3/6Ey+99BJf/epXOf/880+ofYXT6eyxbNmyZZSWlnL//fdTVFREIpFg8uTJRCKRjHSmaab/L4TIuqxjf/qzX9ksXLiQBx98kA8++ABN05g4cSILFizgtddeo76+ngULFqTT3nXXXfziF79g3bp1TJkyBafTyU033ZSR72XLlpFIJHjuueeYNWsWb7zxBmvXrk2vTyQS3HbbbVx22WU98mKz2XosSyQSzJgxg8cee6zHuq5BZNfj0v3YSCmz7ntvy7s73rYH4qGHHuLYsWMZjdcTiQSbN2/m9ttvP+73pCinGxXsKMppZvXq1Vx00UVcf/31FBUVUVxczJ49e7jqqqt6fY/H42HFihWsWLGCr3zlKyxZsoRjx46Rk5ODaZrE4/ETyktdXR0ff/wx9957L/PmzQPgzTffPKFtdVVQUNCv/epu/vz5NDc3s27dOhYsWIAQggULFrBmzRrq6+v553/+53TajpKfr3/960DyQb1r1y4mTJiQTmO327nssst47LHH+OSTTxg7diwzZsxIr6+qqmLHjh3pYLQvVVVV/Pa3vyUQCODxePq9X12NHz+eWCzG5s2b03n55JNPaGhoyEh3Mt9rX+rq6vj973/PE088waRJk9LLE4kE8+bN409/+hNLly4dks9WlKGggh1FOc0sXLiQSZMm8bOf/Yxf//rX3HrrrXznO9/B4/Fw0UUXEQ6Hee+996ivr+fmm2/mF7/4BYWFhUyfPh1N0/i///s/gsEgPp8PSFZr/PnPf+acc87BarX2uzoESPcouu+++ygsLGT//v18//vfH5T97Gu/svF6vUyfPp3/+Z//4Ze//CWQDIAuv/xyotEoCxcuTKcdM2YMTz75JBs3bsTv97N27VqOHDmSEexAsipr2bJlfPTRR+nAqMO//du/sXTpUkpLS7n88svRNI2tW7eybds2fvKTn/TI31VXXcWdd97J8uXL+fGPf0xJSQn79+/nqaee4rvf/S4lJSV9Hpfx48dz/vnn861vfYt77rkH0zS55ZZbsNvt6RIzOLnvtS+PPvooubm56X3uaunSpTz44IMq2FE+V1SbHUU5Dd18883cf//9HDhwgG9+85s88MAD6S7jCxYs4JFHHkm3nXG5XPz7v/87M2fOZNasWezbt4/nn38+/ZC666672LBhA6WlpZx55pkDyoemaTzxxBNs2rSJyZMn8y//8i/ceeedg7KPfe1Xb8477zzi8Xg6sPH7/UycOJH8/PyMQOZHP/oRVVVVXHjhhSxcuJBgMJh1lN9FixaRk5PDjh07uPLKKzPWXXjhhfzxj39kw4YNzJo1i7PPPpu1a9dSXl6eNW8Oh4PXX3+dsrIyLrvsMiZMmMC1115LW1vbgEp6/vu//5uCggLmz5/PpZdeynXXXYfb7c6oOjuZ77UvDz30EJdeemmPQAfg7//+7/njH//IZ599NqifqShDScj+VgQriqIow+LgwYOUlpby0ksv8aUvfWlQt/3II49w00039agmG4hrrrmGhoaG02baDEXpTpXsKIqinGZefvll/vCHP7B37142btzI1772NSoqKpg/f/6QfF5jYyMul4vvfe97A3rfG2+8gcvlytogW1FOJ6pkR1EU5TTzwgsvcMstt7Bnzx7cbjdz585l3bp1vVafnYzm5uZ0lZTP5yMvL6/f721ra+PQoUNAsjo1GAwOev4UZTCoYEdRFEVRlBFNVWMpiqIoijKiqWBHURRFUZQRTQU7iqIoiqKMaCrYURRFURRlRFPBjqIoiqIoI5oKdhRFURRFGdFUsKMoiqIoyoimgh1FURRFUUa0/w+k9AeFdah7BwAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# plot them for fun\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "for i in range(qsos.num_spectra()):\n",
+    "    z = qsos.extra_catalog['Z'][i]\n",
+    "    plt.plot(qsos.wave['brz']/(1+z), qsos.flux['brz'][i], alpha=0.5)\n",
+    "\n",
+    "plt.xlabel('Restframe wavelength [A]')\n",
+    "plt.ylabel('Flux')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5e4f1026-2c4f-4753-92c9-aa4dfefd68af",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## Exercise\n",
+    "\n",
+    "When reading in the spectra from multiple tiles, the code used\n",
+    "```python\n",
+    "for tileid, night, petal in np.unique(bright_qso_zcat['TILEID', 'LASTNIGHT', 'PETAL_LOC']):\n",
+    "    ...\n",
+    "```\n",
+    "\n",
+    "What was the purpose of `np.unique(...)`?  Did it actually matter in this case?"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "DESI main",
+   "language": "python",
+   "name": "desi-main"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
This PR adds a new getting_started tutorial on how to read in multiple spectra files, slice them to selected objects, combine them, and re-write to a new spectra file with an associated redshift catalog.  The idea is that this can be used to subselect objects of interest for future analysis work without having to re-read + re-filter every file every time.

This tutorial is motivated by part of @deisenstein 's question on Slack from a few weeks ago about how to combine spectra and Prospect plot them (though it doesn't cover the Prospect part, which could be another tutorial).

I'll add our new tutorial coordinator Farnik after I have his GitHub ID, but in the meantime I'll mention @forero and @stephjuneau as our former tutorial coordinators.