### PR TITLE
Add helpful message when accessing specprod db from SPARCL notebook

### DIFF
--- a/database/How_to_use_SPARCL_at_NERSC.ipynb
+++ b/database/How_to_use_SPARCL_at_NERSC.ipynb
@@ -11,7 +11,7 @@
    "source": [
     "__author__ = 'Alice Jacques <alice.jacques@noirlab.edu>, Stephanie Juneau <stephanie.juneau@noirlab.edu>, SPARCL team'\n",
     "__version__ = '20241213' # yyyymmdd\n",
-    "__datasets__ = ['sdss_dr16', 'boss_dr16', 'desi_edr', 'desi_dr1']  \n",
+    "__datasets__ = ['sdss_dr16', 'boss_dr16', 'desi_edr', 'desi_dr1']\n",
     "__keywords__ = ['sparcl', 'spectroscopy', 'HowTo', 'sdss spectra', 'desi spectra', 'tutorial']"
    ]
   },
@@ -514,7 +514,8 @@
     "## Data discovery II: using DESI DR1 (iron) database at NERSC\n",
     "The second way you can discover your data is by using DESI DR1 catalogs and databases hosted at NERSC for DESI DR1 (iron). We will focus on the `zpix` catalog for the healpix-based coadded spectra that are in SPARCL. For large queries, this method will work *faster* than using `client.find()` when querying the database. We will work with this method for the remainder of this notebook.\n",
     "\n",
-    "As an example, let's look for a somewhat rare case of low-redshift (`0.3<z<0.4`) quasars (`spectype='QSO'`) and only keep 20 results (`[:20]`)."
+    "The connection to the DR1 database requires a `~/.pgpass` file to store connection credentials. The following code will attempt to connect to the database.  If it fails, it prints the\n",
+    "commands to update your `~/.pgpass` file (but it won't do that automatically in case you did a Jupyter \"run all cells\")."
    ]
   },
   {
@@ -526,8 +527,21 @@
    },
    "outputs": [],
    "source": [
-    "## This step stecifies our database set-up; we select the 'iron' schema for DESI DR1\n",
-    "postgresql = db.setup_db(schema='iron', hostname='specprod-db.desi.lbl.gov', username='desi')"
+    "try:\n",
+    "    postgresql = db.setup_db(schema='iron', hostname='specprod-db.desi.lbl.gov', username='desi_public')\n",
+    "except RuntimeError:\n",
+    "    print(\"\\nIt looks like you need to add access credentials to your $HOME/.pgpass file.\")\n",
+    "    print(\"Try running this from the command line and then rerun this cell.\")\n",
+    "    print()\n",
+    "    print(\"cat /global/common/software/desi/desi_public.pgpass >> ~/.pgpass; chmod 600 ~/.pgpass\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0df784d8",
+   "metadata": {},
+   "source": [
+    "As an example, let's look for a somewhat rare case of low-redshift (`0.3<z<0.4`) quasars (`spectype='QSO'`) and only keep 20 results (`[:20]`)."
    ]
   },
   {
@@ -570,7 +584,7 @@
    },
    "outputs": [],
    "source": [
-    "## For convenience later to join with the output spectra, we convert the query results (q) \n",
+    "## For convenience later to join with the output spectra, we convert the query results (q)\n",
     "## into a Pandas DataFrame (df)\n",
     "found_df_II = pd.DataFrame(data=q)"
    ]
@@ -826,7 +840,7 @@
    "outputs": [],
    "source": [
     "%%time\n",
-    "# We create a list of Spectrum1D objects by iterating over the rows (r) \n",
+    "# We create a list of Spectrum1D objects by iterating over the rows (r)\n",
     "# from the reordered dataframe (df_join)\n",
     "specs = [Spectrum1D(spectral_axis = r.wavelength*u.AA,\n",
     "                    flux = np.array(r.flux)* 10**-17 * u.Unit('erg cm-2 s-1 AA-1'),\n",
@@ -847,10 +861,10 @@
    "outputs": [],
    "source": [
     "# Plot a couple of examples\n",
-    "f, ax = plt.subplots()  \n",
+    "f, ax = plt.subplots()\n",
     "for i in range(3):\n",
     "    valid = specs[i].mask==0\n",
-    "    ax.step(specs[i].spectral_axis[valid], specs[i].flux[valid]) \n",
+    "    ax.step(specs[i].spectral_axis[valid], specs[i].flux[valid])\n",
     "plt.title('Observed Frame')\n",
     "plt.xlabel('Observed $\\lambda\\ [\\AA]$')\n",
     "plt.ylabel('$f_{\\lambda}$ $(10^{-17}$ $erg$ $s^{-1}$ $cm^{-2}$ $\\AA^{-1})$')\n",
@@ -860,7 +874,7 @@
     "f, ax = plt.subplots()\n",
     "for i in range(3):\n",
     "    valid = specs[i].mask==0\n",
-    "    ax.step(specs[i].spectral_axis[valid]/(1.+specs[i].redshift), specs[i].flux[valid]*(1.+specs[i].redshift)) \n",
+    "    ax.step(specs[i].spectral_axis[valid]/(1.+specs[i].redshift), specs[i].flux[valid]*(1.+specs[i].redshift))\n",
     "plt.title('Rest Frame')\n",
     "plt.xlabel('Rest $\\lambda\\ [\\AA]$')\n",
     "plt.ylabel('$f_{\\lambda}$ $(10^{-17}$ $erg$ $s^{-1}$ $cm^{-2}$ $\\AA^{-1})$')\n",
@@ -890,10 +904,10 @@
     "    Pass an index value and the output from using client.retrieve()\n",
     "    to plot the spectrum at the specified index.\n",
     "    \"\"\"\n",
-    "    \n",
+    "\n",
     "    record = results.loc[index]\n",
     "\n",
-    "    # We renamed specid to targetid for DESI (specid=specobjid for SDSS/BOSS) \n",
+    "    # We renamed specid to targetid for DESI (specid=specobjid for SDSS/BOSS)\n",
     "    specid = record.targetid\n",
     "    data_release = record.data_release\n",
     "\n",
@@ -916,16 +930,16 @@
     "              f\"Dec = {dec}\", loc='left')\n",
     "    plt.xlabel('$\\lambda\\ [\\AA]$')\n",
     "    plt.ylabel('$f_{\\lambda}$ $(10^{-17}$ $erg$ $s^{-1}$ $cm^{-2}$ $\\AA^{-1})$')\n",
-    "    \n",
+    "\n",
     "    # Plot unsmoothed spectrum in grey\n",
     "    plt.plot(wavelength[mask==0], flux[mask==0], color='k', alpha=0.2, label='Unsmoothed spectrum')\n",
-    "    \n",
+    "\n",
     "    # Overplot spectrum smoothed using a 1-D Gaussian Kernel in black\n",
     "    plt.plot(wavelength[mask==0], convolve(flux[mask==0], Gaussian1DKernel(5)), color='k', label='Smoothed spectrum')\n",
-    "    \n",
+    "\n",
     "    # Overplot the model spectrum in red\n",
     "    plt.plot(wavelength[mask==0], model[mask==0], color='r', label='Model spectrum')\n",
-    "    \n",
+    "\n",
     "    plt.legend()\n",
     "    plt.show()"
    ]

--- a/database/spectroscopic-production-database.ipynb
+++ b/database/spectroscopic-production-database.ipynb
@@ -22,11 +22,7 @@
     "\n",
     "## Initial Setup\n",
     "\n",
-    "This just imports everything we need and sets up paths and environment variables so we can find things.\n",
-    "\n",
-    "## DR1 TO DO\n",
-    "\n",
-    "* Currently the `desi` user is needed for testing. Switch back to `desi_public`."
+    "This just imports everything we need and sets up paths and environment variables so we can find things."
    ]
   },
   {
@@ -181,7 +177,7 @@
     "# ...\n",
     "db.log = get_logger()\n",
     "try:\n",
-    "    postgresql = db.setup_db(schema=specprod, hostname='specprod-db.desi.lbl.gov', username='desi')\n",
+    "    postgresql = db.setup_db(schema=specprod, hostname='specprod-db.desi.lbl.gov', username='desi_public')\n",
     "except RuntimeError:\n",
     "    print(\"\\nIt looks like you need to add access credentials to your $HOME/.pgpass file.\")\n",
     "    print(\"Try running this from the command line and then rerun this cell.\")\n",


### PR DESCRIPTION
This PR "minimally" closes #105, and also prepares the notebooks for DR1 by setting the specprod database access user to `desi_public`.

I noticed that there was a branch `sparcl_nb_update` that may or may not also include the error message requested in #105. That branch will probably need `dr1` merged into it anyway before further work.